### PR TITLE
Fix coloring issues on light backgrounds

### DIFF
--- a/log/fieldmapper.go
+++ b/log/fieldmapper.go
@@ -71,7 +71,6 @@ func Table(mapper FieldMapper) {
 
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetColMinWidth(0, 12)
-	// table.SetColMinWidth(1, 68)
 	table.SetColWidth(68)
 
 	for _, key := range keys {

--- a/log/log.go
+++ b/log/log.go
@@ -2,6 +2,7 @@ package log
 
 import (
 	"fmt"
+	"github.com/logrusorgru/aurora"
 	"strings"
 )
 
@@ -56,6 +57,22 @@ func Highlightf(format string, a ...interface{}) {
 		return
 	}
 	fmt.Print(opt.theme.formatHighlight(fmt.Sprintf(format, a...)))
+}
+
+func Bold(a ...interface{}) {
+	if opt.echo {
+		echo(a...)
+		return
+	}
+	fmt.Println(aurora.Bold(joined(a...)))
+}
+
+func Boldf(format string, a ...interface{}) {
+	if opt.echo {
+		echof(format, a...)
+		return
+	}
+	fmt.Print(aurora.Bold(fmt.Sprintf(format, a...)))
 }
 
 // Debug logs a debug message

--- a/log/theme.go
+++ b/log/theme.go
@@ -22,7 +22,7 @@ func (t *defaultTheme) formatLevel(level logLevel, text string) aurora.Value {
 	case errorLevel:
 		return aurora.Red(text)
 	default:
-		return aurora.White(text)
+		return aurora.Reset(text)
 	}
 }
 
@@ -31,14 +31,14 @@ func (t *defaultTheme) formatStyle(style fieldStyle, text string) aurora.Value {
 	case keyFieldStyle, headerFieldStyle:
 		return aurora.Blue(text)
 	case valueFieldStyle, cellFieldStyle:
-		return aurora.White(text)
+		fallthrough
 	default:
-		return aurora.White(text)
+		return aurora.Reset(text)
 	}
 }
 
 func (t *defaultTheme) formatRegular(text string) aurora.Value {
-	return aurora.White(text)
+	return aurora.Reset(text)
 }
 
 func (t *defaultTheme) formatHighlight(text string) aurora.Value {
@@ -58,7 +58,7 @@ func (t *grayscaleTheme) formatLevel(level logLevel, text string) aurora.Value {
 	case errorLevel:
 		return aurora.Gray(1-1, text).BgGray(24 - 1)
 	default:
-		return aurora.White(text)
+		return aurora.Reset(text)
 	}
 }
 
@@ -67,14 +67,14 @@ func (t *grayscaleTheme) formatStyle(style fieldStyle, text string) aurora.Value
 	case keyFieldStyle, headerFieldStyle:
 		return aurora.Gray(24-1, text)
 	case valueFieldStyle, cellFieldStyle:
-		return aurora.White(text)
+		fallthrough
 	default:
-		return aurora.White(text)
+		return aurora.Reset(text)
 	}
 }
 
 func (t *grayscaleTheme) formatRegular(text string) aurora.Value {
-	return aurora.White(text)
+	return aurora.Reset(text)
 }
 
 func (t *grayscaleTheme) formatHighlight(text string) aurora.Value {

--- a/task/task.go
+++ b/task/task.go
@@ -73,7 +73,7 @@ func ShowConfig(asJSON bool, asYAML bool, asTree bool) {
 	m := cfg.Manifest()
 
 	if asJSON || asYAML {
-		log.Highlight("[manifest]")
+		log.Bold("[manifest]")
 		if asJSON {
 			log.Regular(m.AsJSON())
 			log.Regular()
@@ -86,19 +86,19 @@ func ShowConfig(asJSON bool, asYAML bool, asTree bool) {
 			return
 		}
 
-		log.Highlight("[profile]")
+		log.Bold("[profile]")
 		log.Regular(strings.TrimSpace(lines))
 	} else if asTree {
 		tree.PrintHr(m)
 	} else {
-		log.Regular("[manifest]")
+		log.Bold("[manifest]")
 		logFields(m, m.Config.Verbose)
 
-		log.Regular("\n[config]")
+		log.Bold("\n[config]")
 		logFields(m.Config, m.Config.Verbose)
 
 		if len(m.Commands) > 0 {
-			log.Regular("\n[commands]")
+			log.Bold("\n[commands]")
 			for _, cmd := range m.Commands {
 				cmd.Walk(func(c *model.Command, s *bool) {
 					logFields(c, m.Config.Verbose)


### PR DESCRIPTION
Fixes Issue #11 

This uses `aurora.Reset` instead of `aurora.White` which will use the terminal's default color so it shows up correctly in different backgrounds.