### PR TITLE
Add cmd mode

### DIFF
--- a/cmd/addcmd.go
+++ b/cmd/addcmd.go
@@ -14,6 +14,7 @@ var (
 	code        string
 	language    string
 	aliasOnly   bool
+	mode        string
 )
 
 // addcmdCmd represents the addcmd command
@@ -26,14 +27,25 @@ the alias which can be run as "key path" for the actual command provided.
 
 This will create appropriate command scopes for all levels in
 the provided key path. A command scope can a tree of sub commands
-and substitutions.`,
+and substitutions.
+
+A command's mode indicates how it will be executed. By default, nostromo
+concatenates parent and child commands along the tree. There are 3 modes
+available to commands:
+
+  concatenate  Concatenate this command with subcommands exactly as defined
+  independent  Execute this command with subcommands using ';' to separate
+  exclusive    Execute this and only this command ignoring parent commands
+
+You can set using -m or --mode when adding a command or globally using:
+  nostromo manifest set mode <mode>`,
 	Args: addCmdArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		name := ""
 		if len(args) > 1 {
 			name = args[1]
 		}
-		task.AddCommand(args[0], name, description, code, language, aliasOnly)
+		task.AddCommand(args[0], name, description, code, language, aliasOnly, mode)
 	},
 }
 
@@ -45,10 +57,7 @@ func init() {
 	addcmdCmd.Flags().StringVarP(&code, "code", "c", "", "Code snippet to run for this command")
 	addcmdCmd.Flags().StringVarP(&language, "language", "l", "", "Language of code snippet (e.g., ruby, python, perl, js)")
 	addcmdCmd.Flags().BoolVarP(&aliasOnly, "alias-only", "a", false, "Add shell alias only, not a nostromo command")
-}
-
-func codeEmpty() bool {
-	return len(code) == 0 && len(language) == 0
+	addcmdCmd.Flags().StringVarP(&mode, "mode", "m", "", "Set the mode for the command (concatenate, independent, exclusive)")
 }
 
 func codeValid() bool {

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -13,8 +13,9 @@ var setCmd = &cobra.Command{
 Nostromo config items are saved in the manifest.
 
 Use this command to set values for these settings:
-verbose: true | false
-aliasesOnly: true | false`,
+  verbose: true | false
+  aliasesOnly: true | false
+  mode: concatenate | independent | exclusive`,
 	Args: cobra.MinimumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		task.SetConfig(args[0], args[1])

--- a/config/config.go
+++ b/config/config.go
@@ -130,6 +130,8 @@ func (c *Config) Get(key string) string {
 		return strconv.FormatBool(c.manifest.Config.Verbose)
 	case "aliasesOnly":
 		return strconv.FormatBool(c.manifest.Config.AliasesOnly)
+	case "mode":
+		return c.manifest.Config.Mode.String()
 	}
 	return "key not found"
 }
@@ -150,6 +152,12 @@ func (c *Config) Set(key, value string) error {
 			return err
 		}
 		c.manifest.Config.AliasesOnly = aliasesOnly
+		return nil
+	case "mode":
+		if !model.IsModeSupported(value) {
+			return fmt.Errorf("invalid mode, supported modes: %s", model.SupportedModes())
+		}
+		c.manifest.Config.Mode = model.ModeFromString(value)
 		return nil
 	}
 	return fmt.Errorf("key not found")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -183,7 +183,7 @@ func TestKeys(t *testing.T) {
 		config   *Config
 		expected []string
 	}{
-		{"keys", NewConfig("path", fakeManifest()), []string{"verbose", "aliasesOnly"}},
+		{"keys", NewConfig("path", fakeManifest()), []string{"verbose", "aliasesOnly", "mode"}},
 	}
 
 	for _, test := range tests {
@@ -207,6 +207,7 @@ func TestFields(t *testing.T) {
 			map[string]interface{}{
 				"verbose":     false,
 				"aliasesOnly": false,
+				"mode": model.ConcatenateMode.String(),
 			},
 		},
 	}
@@ -222,7 +223,7 @@ func TestFields(t *testing.T) {
 
 func fakeManifest() *model.Manifest {
 	m := model.NewManifest()
-	m.AddCommand("one.two.three", "command", "", &model.Code{}, false)
+	m.AddCommand("one.two.three", "command", "", &model.Code{}, false, "concatenate")
 	m.AddSubstitution("one.two", "name", "alias")
 	return m
 }

--- a/model/code.go
+++ b/model/code.go
@@ -7,5 +7,5 @@ type Code struct {
 }
 
 func (c *Code) valid() bool {
-	return len(c.Snippet) > 0 && len(c.Language) > 0
+	return c != nil && len(c.Snippet) > 0 && len(c.Language) > 0
 }

--- a/model/command_test.go
+++ b/model/command_test.go
@@ -463,3 +463,34 @@ func fakeBuiltCommand(startDepth, endDepth int, keyPath, command string) *Comman
 	}
 	return first
 }
+
+func TestCommandEffectiveCommand(t *testing.T) {
+	type fields struct {
+		Name string
+		Code        *Code
+		Mode        Mode
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{"use code", fields{"",&Code{"js", "code"}, ConcatenateMode}, "code"},
+		{"concatenate", fields{"command", nil, ConcatenateMode}, "command"},
+		{"independent", fields{"command", nil, IndependentMode}, "command;"},
+		{"exclusive", fields{"command", nil, ExclusiveMode}, "command;"},
+		{"empty command", fields{"", nil, ExclusiveMode}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Command{
+				Name: tt.fields.Name,
+				Code:        tt.fields.Code,
+				Mode:        tt.fields.Mode,
+			}
+			if got := c.effectiveCommand(); got != tt.want {
+				t.Errorf("effectiveCommand() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/model/command_test.go
+++ b/model/command_test.go
@@ -21,14 +21,14 @@ func TestNewCommand(t *testing.T) {
 		code        *Code
 		expected    *Command
 	}{
-		{"empty alias", "cmd", "", false, "", nil, &Command{nil, "cmd", "cmd", "cmd", false, "", map[string]*Command{}, map[string]*Substitution{}, &Code{}}},
-		{"empty name", "", "alias", false, "", nil, &Command{nil, "alias", "", "alias", false, "", map[string]*Command{}, map[string]*Substitution{}, &Code{}}},
-		{"valid alias", "cmd", "cmd-alias", false, "description", nil, &Command{nil, "cmd-alias", "cmd", "cmd-alias", false, "description", map[string]*Command{}, map[string]*Substitution{}, &Code{}}},
+		{"empty alias", "cmd", "", false, "", nil, &Command{nil, "cmd", "cmd", "cmd", false, "", map[string]*Command{}, map[string]*Substitution{}, &Code{}, ConcatenateMode}},
+		{"empty name", "", "alias", false, "", nil, &Command{nil, "alias", "", "alias", false, "", map[string]*Command{}, map[string]*Substitution{}, &Code{}, ConcatenateMode}},
+		{"valid alias", "cmd", "cmd-alias", false, "description", nil, &Command{nil, "cmd-alias", "cmd", "cmd-alias", false, "description", map[string]*Command{}, map[string]*Substitution{}, &Code{}, ConcatenateMode}},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actual := newCommand(test.cmdName, test.alias, test.description, test.code, test.aliasOnly)
+			actual := newCommand(test.cmdName, test.alias, test.description, test.code, test.aliasOnly, ConcatenateMode.String())
 			if !reflect.DeepEqual(test.expected, actual) {
 				t.Errorf("expected: %s, actual: %s", test.expected, actual)
 			}
@@ -300,7 +300,7 @@ func TestBuild(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			test.command.build(test.keyPath, test.commandStr, "", &Code{}, test.aliasOnly)
+			test.command.build(test.keyPath, test.commandStr, "", &Code{}, test.aliasOnly, ConcatenateMode.String())
 			if !reflect.DeepEqual(test.expected, test.command) {
 				t.Errorf("expected: %s, actual: %s", test.expected, test.command)
 			}
@@ -332,7 +332,7 @@ func TestKeys(t *testing.T) {
 		command  *Command
 		expected []string
 	}{
-		{"keys", fakeCommand(1), []string{"keypath", "alias", "command", "description", "commands", "substitutions", "code"}},
+		{"keys", fakeCommand(1), []string{"keypath", "alias", "command", "description", "commands", "substitutions", "code", "mode"}},
 	}
 
 	for _, test := range tests {
@@ -361,6 +361,7 @@ func TestFields(t *testing.T) {
 				"substitutions": "one-sub",
 				"code":          false,
 				"keypath":       "one-alias",
+				"mode": "concatenate",
 			},
 		},
 	}
@@ -434,7 +435,7 @@ func fakeCommandWithPrefix(depth int, prefix string) *Command {
 	var cmd *Command
 	for i := 0; i < depth; i++ {
 		name := depthKeys[i+1]
-		cmd = newCommand(prefix+name, prefix+name+"-alias", "", nil, false)
+		cmd = newCommand(prefix+name, prefix+name+"-alias", "", nil, false, ConcatenateMode.String())
 		cmd.addSubstitution(&Substitution{prefix + name, prefix + name + "-sub"})
 		if lastCmd != nil {
 			lastCmd.addCommand(cmd)

--- a/model/config.go
+++ b/model/config.go
@@ -4,11 +4,12 @@ package model
 type Config struct {
 	Verbose     bool `json:"verbose"`
 	AliasesOnly bool `json:"aliasesOnly"`
+	Mode        Mode `json:"mode"`
 }
 
 // Keys as ordered list of fields for logging
 func (c *Config) Keys() []string {
-	return []string{"verbose", "aliasesOnly"}
+	return []string{"verbose", "aliasesOnly", "mode"}
 }
 
 // Fields interface for logging
@@ -16,5 +17,6 @@ func (c *Config) Fields() map[string]interface{} {
 	return map[string]interface{}{
 		"verbose":     c.Verbose,
 		"aliasesOnly": c.AliasesOnly,
+		"mode":        c.Mode.String(),
 	}
 }

--- a/model/config_test.go
+++ b/model/config_test.go
@@ -11,7 +11,7 @@ func TestConfigKeys(t *testing.T) {
 		manifest *Manifest
 		expected []string
 	}{
-		{"keys", fakeManifest(1, 1), []string{"verbose", "aliasesOnly"}},
+		{"keys", fakeManifest(1, 1), []string{"verbose", "aliasesOnly", "mode"}},
 	}
 
 	for _, test := range tests {
@@ -35,6 +35,7 @@ func TestConfigFields(t *testing.T) {
 			map[string]interface{}{
 				"verbose":     true,
 				"aliasesOnly": false,
+				"mode": "concatenate",
 			},
 		},
 	}

--- a/model/manifest.go
+++ b/model/manifest.go
@@ -38,14 +38,19 @@ func (m *Manifest) Link() {
 }
 
 // AddCommand tree up to key path
-func (m *Manifest) AddCommand(keyPath, command, description string, code *Code, aliasOnly bool) error {
+func (m *Manifest) AddCommand(keyPath, command, description string, code *Code, aliasOnly bool, mode string) error {
 	if len(keyPath) == 0 {
 		return fmt.Errorf("invalid key path")
 	}
 
+	// Use config mode if not supplied on CLI
+	if len(mode) == 0 {
+		mode = m.Config.Mode.String()
+	}
+
 	// Only need to create one command for alias only mode
 	if m.Config.AliasesOnly || aliasOnly {
-		cmd := newCommand(command, keyPath, description, code, true)
+		cmd := newCommand(command, keyPath, description, code, true, mode)
 		m.Commands[cmd.Alias] = cmd
 		return nil
 	}
@@ -55,12 +60,12 @@ func (m *Manifest) AddCommand(keyPath, command, description string, code *Code, 
 	cmd := m.Commands[key]
 	if cmd == nil {
 		// Create new command to build our the rest
-		cmd = newCommand("", key, "", nil, false)
+		cmd = newCommand("", key, "", nil, false, mode)
 		m.Commands[cmd.Alias] = cmd
 	}
 
 	// Modify or build the rest of the key path of commands
-	cmd.build(keyPath, command, description, code, aliasOnly)
+	cmd.build(keyPath, command, description, code, aliasOnly, mode)
 
 	return nil
 }

--- a/model/mode.go
+++ b/model/mode.go
@@ -1,0 +1,62 @@
+package model
+
+type Mode int
+
+const (
+	// ConcatenateMode will join this command to sub-commands and is the default. Use
+	// this when combining the command nodes together to generate a single command string to
+	// evaluate.
+	ConcatenateMode Mode = iota
+
+	// IndependentMode will run this command independently of others by suffixing the
+	// execution string with a ';'. Note the parent commands may still be run depending on
+	// the mode set on them. This is convenient for separating commands that should always run.
+	IndependentMode
+
+	// ExclusiveMode will run this command exclusively without walking up the command tree
+	// to join or run other commands. This is similar to `IndependentMode` and will add a
+	// ';' at the end of the execution string so sub-commands cannot be concatenated. However,
+	// it means that `nostromo` will only run this command. Substitutions are still fully scoped.
+	ExclusiveMode
+)
+
+var supportedModes = map[string]Mode{
+	ConcatenateMode.String(): ConcatenateMode,
+	IndependentMode.String(): IndependentMode,
+	ExclusiveMode.String():   ExclusiveMode,
+}
+
+func (m Mode) String() string {
+	switch m {
+	case ConcatenateMode:
+		return "concatenate"
+	case IndependentMode:
+		return "independent"
+	case ExclusiveMode:
+		return "exclusive"
+	}
+	return "unknown"
+}
+
+// IsModeSupported returns true if mode is supported and false otherwise.
+func IsModeSupported(mode string) bool {
+	_, ok := supportedModes[mode]
+	return ok
+}
+
+// ModeFromString converts a string to a Mode and defaults to ConcatenateMode if not mappable.
+func ModeFromString(mode string) Mode {
+	m, ok := supportedModes[mode]
+	if !ok {
+		m = ConcatenateMode // default
+	}
+	return m
+}
+
+func SupportedModes() []string {
+	var modes []string
+	for _, mode := range supportedModes {
+		modes = append(modes, mode.String())
+	}
+	return modes
+}

--- a/model/mode_test.go
+++ b/model/mode_test.go
@@ -1,0 +1,96 @@
+package model
+
+import (
+	"testing"
+)
+
+func TestModeString(t *testing.T) {
+	tests := []struct {
+		name string
+		m    Mode
+		want string
+	}{
+		{"concatenate", ConcatenateMode, "concatenate"},
+		{"independent", IndependentMode, "independent"},
+		{"exclusive", ExclusiveMode, "exclusive"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.m.String(); got != tt.want {
+				t.Errorf("String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsModeSupported(t *testing.T) {
+	type args struct {
+		mode string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{"concatenate", args{"concatenate"}, true},
+		{"independent", args{"independent"}, true},
+		{"exclusive", args{"exclusive"}, true},
+		{"not supported", args{"not supported"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsModeSupported(tt.args.mode); got != tt.want {
+				t.Errorf("IsModeSupported() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSupportedModes(t *testing.T) {
+	tests := []struct {
+		name string
+		want []string
+	}{
+		{"supported modes", []string{"concatenate", "independent", "exclusive"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SupportedModes()
+			for _, mode := range tt.want {
+				found := false
+				for _, exp := range got {
+					if mode == exp {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("SupportedModes() = %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestModeFromString(t *testing.T) {
+	type args struct {
+		mode string
+	}
+	tests := []struct {
+		name string
+		args args
+		want Mode
+	}{
+		{"concatenate", args{"concatenate"}, ConcatenateMode},
+		{"independent", args{"independent"}, IndependentMode},
+		{"exclusive", args{"exclusive"}, ExclusiveMode},
+		{"not supported", args{"not supported"}, ConcatenateMode},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ModeFromString(tt.args.mode); got != tt.want {
+				t.Errorf("ModeFromString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/shell/startupfile_test.go
+++ b/shell/startupfile_test.go
@@ -180,7 +180,7 @@ func makeManifestLong(match bool, aliasOnly bool, cmds ...string) *model.Manifes
 		if !match {
 			cmd = ""
 		}
-		m.AddCommand(alias, cmd, "", nil, aliasOnly)
+		m.AddCommand(alias, cmd, "", nil, aliasOnly, "concatenate")
 	}
 	return m
 }

--- a/task/task.go
+++ b/task/task.go
@@ -55,6 +55,8 @@ func DestroyConfig() {
 		return
 	}
 
+	log.Highlight("nostromo config deleted")
+
 	err = shell.Commit(model.NewManifest())
 	if err != nil {
 		log.Error(err)
@@ -98,6 +100,12 @@ func ShowConfig(asJSON bool, asYAML bool, asTree bool) {
 					}
 				})
 			}
+		} else if m.Config.Verbose {
+			log.Regular()
+		}
+
+		if !m.Config.Verbose {
+			log.Regular()
 		}
 	}
 
@@ -107,7 +115,11 @@ func ShowConfig(asJSON bool, asYAML bool, asTree bool) {
 	}
 
 	log.Bold("[profile]")
-	log.Regular(strings.TrimSpace(lines))
+	if len(lines) > 0 {
+		log.Regular(strings.TrimSpace(lines))
+	} else {
+		log.Regular("empty")
+	}
 }
 
 // SetConfig updates properties for nostromo settings
@@ -140,7 +152,7 @@ func GetConfig(key string) {
 }
 
 // AddCommand to the manifest
-func AddCommand(keyPath, command, description, code, language string, aliasOnly bool) {
+func AddCommand(keyPath, command, description, code, language string, aliasOnly bool, mode string) {
 	cfg := checkConfig()
 	if cfg == nil {
 		return
@@ -153,7 +165,7 @@ func AddCommand(keyPath, command, description, code, language string, aliasOnly 
 		Snippet:  code,
 	}
 
-	err := m.AddCommand(keyPath, command, description, snippet, aliasOnly)
+	err := m.AddCommand(keyPath, command, description, snippet, aliasOnly, mode)
 	if err != nil {
 		log.Error(err)
 		return

--- a/testdata/manifest.json
+++ b/testdata/manifest.json
@@ -2,7 +2,8 @@
   "version": "1.0",
   "config": {
     "verbose": true,
-    "aliasesOnly": false
+    "aliasesOnly": false,
+    "mode": 0
   },
   "commands": {
     "0-one-alias": {
@@ -42,7 +43,8 @@
                   "code": {
                     "language": "",
                     "snippet": ""
-                  }
+                  },
+                  "mode": 0
                 }
               },
               "subs": {
@@ -54,7 +56,8 @@
               "code": {
                 "language": "",
                 "snippet": ""
-              }
+              },
+              "mode": 0
             }
           },
           "subs": {
@@ -66,7 +69,8 @@
           "code": {
             "language": "",
             "snippet": ""
-          }
+          },
+          "mode": 0
         }
       },
       "subs": {
@@ -78,7 +82,8 @@
       "code": {
         "language": "",
         "snippet": ""
-      }
+      },
+      "mode": 0
     },
     "1-one-alias": {
       "keyPath": "1-one-alias",
@@ -117,7 +122,8 @@
                   "code": {
                     "language": "",
                     "snippet": ""
-                  }
+                  },
+                  "mode": 0
                 }
               },
               "subs": {
@@ -129,7 +135,8 @@
               "code": {
                 "language": "",
                 "snippet": ""
-              }
+              },
+              "mode": 0
             }
           },
           "subs": {
@@ -141,7 +148,8 @@
           "code": {
             "language": "",
             "snippet": ""
-          }
+          },
+          "mode": 0
         }
       },
       "subs": {
@@ -153,7 +161,8 @@
       "code": {
         "language": "",
         "snippet": ""
-      }
+      },
+      "mode": 0
     }
   }
 }

--- a/testdata/manifest.yaml
+++ b/testdata/manifest.yaml
@@ -2,6 +2,7 @@ version: "1.0"
 config:
   verbose: true
   aliasesonly: false
+  mode: 0
 commands:
   0-one-alias:
     keypath: 0-one-alias
@@ -38,6 +39,7 @@ commands:
                 code:
                   language: ""
                   snippet: ""
+                mode: 0
             subs:
               0-three-sub:
                 name: 0-three
@@ -45,6 +47,7 @@ commands:
             code:
               language: ""
               snippet: ""
+            mode: 0
         subs:
           0-two-sub:
             name: 0-two
@@ -52,6 +55,7 @@ commands:
         code:
           language: ""
           snippet: ""
+        mode: 0
     subs:
       0-one-sub:
         name: 0-one
@@ -59,6 +63,7 @@ commands:
     code:
       language: ""
       snippet: ""
+    mode: 0
   1-one-alias:
     keypath: 1-one-alias
     name: 1-one
@@ -94,6 +99,7 @@ commands:
                 code:
                   language: ""
                   snippet: ""
+                mode: 0
             subs:
               1-three-sub:
                 name: 1-three
@@ -101,6 +107,7 @@ commands:
             code:
               language: ""
               snippet: ""
+            mode: 0
         subs:
           1-two-sub:
             name: 1-two
@@ -108,6 +115,7 @@ commands:
         code:
           language: ""
           snippet: ""
+        mode: 0
     subs:
       1-one-sub:
         name: 1-one
@@ -115,3 +123,4 @@ commands:
     code:
       language: ""
       snippet: ""
+    mode: 0


### PR DESCRIPTION
Fixes #14 and #6.

New feature which adds `mode` to commands including:
```
concatenate
independent
exclusive
```

The default mode is `concatenate` which adds commands together along the tree before executing.
The `independent` mode adds a `;` which causes each command to execute separately.
The `exclusive` mode runs only the command and doesn't combine with parent commands.