### PR TITLE
Configure base config location with NOSTROMO_HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ This command will initialize nostromo and create a manifest under `~/.nostromo`:
 nostromo init
 ```
 
+To customize the directory (and change it from `~/.nostromo`), set the
+`NOSTROMO_HOME` environment variable to a location of your choosing.
+
 To destroy the manifest and start over you can always run:
 ```sh
 nostromo destroy

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -11,8 +11,10 @@ var destroyCmd = &cobra.Command{
 	Use:   "destroy",
 	Short: "Delete nostromo configuration",
 	Long: `Deletes nostromo config file.
-	
-The config file is located at ~/.nostromo/config`,
+
+By default the config file is located at ~/.nostromo/manifest.yaml.
+
+Customize this with the $NOSTROMO_HOME environment variable`,
 	Run: func(cmd *cobra.Command, args []string) {
 		os.Exit(task.DestroyConfig())
 	},

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -11,8 +11,10 @@ var initCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Initialize nostromo config file",
 	Long: `Create a nostromo config file with defaults.
-	
-The config file is located at ~/.nostromo/config`,
+
+By default the config file is located at ~/.nostromo/manifest.yaml.
+
+Customize this with the $NOSTROMO_HOME environment variable`,
 	Run: func(cmd *cobra.Command, args []string) {
 		os.Exit(task.InitConfig())
 	},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 
+	"github.com/pokanop/nostromo/config"
 	"github.com/pokanop/nostromo/log"
 	"github.com/pokanop/nostromo/task"
 	"github.com/pokanop/nostromo/version"
@@ -55,10 +56,11 @@ func init() {
 
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
-	viper.SetConfigName("env")             // name of config file (without extension)
-	viper.AddConfigPath("$HOME")           // adding home directory as first search path
-	viper.AddConfigPath("$HOME/.nostromo") // adding .nostromo directory to search path
-	viper.AutomaticEnv()                   // read in environment variables that match
+	nostromoPath := config.GetBaseDir()		 // get base path. (by default ~/.nostromo)
+	viper.SetConfigName("env")						 // name of config file (without extension)
+	viper.AddConfigPath("$HOME")					 // adding home directory as first search path
+	viper.AddConfigPath(nostromoPath)			 // adding nostromo directory to search path
+	viper.AutomaticEnv()									 // read in environment variables that match
 }
 
 func printUsage(cmd *cobra.Command) {

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -19,7 +19,9 @@ var showCmd = &cobra.Command{
 	Long: `Prints nostromo config with command tree
 and profile changes.
 
-The config file is located at ~/.nostromo/config`,
+By default the config file is located at ~/.nostromo/manifest.yaml.
+
+Customize this with the $NOSTROMO_HOME environment variable`,
 	Run: func(cmd *cobra.Command, args []string) {
 		os.Exit(task.ShowConfig(asJSON, asYAML, asTree))
 	},

--- a/config/config.go
+++ b/config/config.go
@@ -14,7 +14,8 @@ import (
 
 // Path for standard nostromo config
 const (
-	Path = "~/.nostromo/manifest.yaml"
+	DefaultManifestFile = "manifest.yaml"
+	DefaultBaseDir = "~/.nostromo"
 )
 
 // Config manages working with nostromo configuration files
@@ -28,6 +29,23 @@ type Config struct {
 // NewConfig returns a new nostromo config
 func NewConfig(path string, manifest *model.Manifest) *Config {
 	return &Config{path, manifest}
+}
+
+// GetBaseDir returns the base directory for nostromo files
+func GetBaseDir() string {
+	customDir := os.Getenv("NOSTROMO_HOME")
+
+	if customDir != "" {
+		return customDir
+	}
+
+	return DefaultBaseDir
+}
+
+// GetConfigPath joins the base directory and the manifest file
+func GetConfigPath() string {
+	baseDir := GetBaseDir()
+	return filepath.Join(baseDir, DefaultManifestFile)
 }
 
 // Parse nostromo config at path into a `Manifest` object

--- a/task/task.go
+++ b/task/task.go
@@ -26,8 +26,10 @@ func InitConfig() int {
 	cfg := checkConfigQuiet()
 
 	if cfg == nil {
-		cfg = config.NewConfig(config.Path, model.NewManifest())
-		err := pathutil.EnsurePath("~/.nostromo")
+		baseDir := config.GetBaseDir()
+		configPath := config.GetConfigPath()
+		cfg = config.NewConfig(configPath, model.NewManifest())
+		err := pathutil.EnsurePath(baseDir)
 		if err != nil {
 			log.Error(err)
 			return -1
@@ -457,7 +459,8 @@ func checkConfig() *config.Config {
 }
 
 func checkConfigCommon(quiet bool) *config.Config {
-	cfg, err := config.Parse(config.Path)
+	configPath := config.GetConfigPath()
+	cfg, err := config.Parse(configPath)
 	if err != nil {
 		if !quiet {
 			log.Error(err)


### PR DESCRIPTION
This change allows users to change the base location of nostromo config
to a directory of their choosing, by setting the `NOSTROMO_HOME`
environment variable in their shell.

Closes #26