### PR TITLE
Adjust lookup of startup files to respect ZDOTDIR

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -56,11 +56,11 @@ func init() {
 
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
-	nostromoPath := config.GetBaseDir()		 // get base path. (by default ~/.nostromo)
-	viper.SetConfigName("env")						 // name of config file (without extension)
-	viper.AddConfigPath("$HOME")					 // adding home directory as first search path
-	viper.AddConfigPath(nostromoPath)			 // adding nostromo directory to search path
-	viper.AutomaticEnv()									 // read in environment variables that match
+	nostromoPath := config.GetBaseDir() // get base path. (by default ~/.nostromo)
+	viper.SetConfigName("env")          // name of config file (without extension)
+	viper.AddConfigPath("$HOME")        // adding home directory as first search path
+	viper.AddConfigPath(nostromoPath)   // adding nostromo directory to search path
+	viper.AutomaticEnv()                // read in environment variables that match
 }
 
 func printUsage(cmd *cobra.Command) {

--- a/config/config.go
+++ b/config/config.go
@@ -15,7 +15,7 @@ import (
 // Path for standard nostromo config
 const (
 	DefaultManifestFile = "manifest.yaml"
-	DefaultBaseDir = "~/.nostromo"
+	DefaultBaseDir      = "~/.nostromo"
 )
 
 // Config manages working with nostromo configuration files

--- a/shell/startupfile.go
+++ b/shell/startupfile.go
@@ -15,23 +15,23 @@ import (
 
 const (
 	beginBlockComment = "# nostromo [section begin]"
-	endBlockComment		= "# nostromo [section end]"
-	sourceCompletion	= "eval \"$(nostromo completion)\""
+	endBlockComment   = "# nostromo [section end]"
+	sourceCompletion  = "eval \"$(nostromo completion)\""
 )
 
 var (
-	startupFilenames = []string{".profile", ".bash_profile", ".bashrc", ".zshrc"}
-	preferredFilenames	 = []string{".bashrc", ".zshrc"}
+	startupFilenames   = []string{".profile", ".bash_profile", ".bashrc", ".zshrc"}
+	preferredFilenames = []string{".bashrc", ".zshrc"}
 )
 
 type startupFile struct {
-	path					 string
-	mode					 os.FileMode
-	content				 string
+	path           string
+	mode           os.FileMode
+	content        string
 	updatedContent string
-	commands			 map[string]*model.Command
-	preferred			 bool
-	pristine			 bool
+	commands       map[string]*model.Command
+	preferred      bool
+	pristine       bool
 }
 
 func isPreferredFilename(filename string) bool {
@@ -92,8 +92,8 @@ func findStartupFile(name string) (string, os.FileMode, error) {
 	}
 
 	// zsh doesn't always have a ~/.zshrc file, and if it doesn't,
-  // it does have a $ZDOTDIR/.zshrc
-  // https://wiki.archlinux.org/index.php/Zsh#Startup.2FShutdown_files
+	// it does have a $ZDOTDIR/.zshrc
+	// https://wiki.archlinux.org/index.php/Zsh#Startup.2FShutdown_files
 	zdotDir := os.Getenv("ZDOTDIR")
 	var path string
 	if zdotDir != "" {
@@ -133,9 +133,9 @@ func parseStartupFile(path string, mode os.FileMode) (*startupFile, error) {
 
 func newStartupFile(path, content string, mode os.FileMode) *startupFile {
 	return &startupFile{
-		path:			 path,
-		mode:			 mode,
-		content:	 content,
+		path:      path,
+		mode:      mode,
+		content:   content,
 		commands:  map[string]*model.Command{},
 		preferred: isPreferredFilename(path),
 	}

--- a/shell/startupfile.go
+++ b/shell/startupfile.go
@@ -15,23 +15,23 @@ import (
 
 const (
 	beginBlockComment = "# nostromo [section begin]"
-	endBlockComment   = "# nostromo [section end]"
-	sourceCompletion  = "eval \"$(nostromo completion)\""
+	endBlockComment		= "# nostromo [section end]"
+	sourceCompletion	= "eval \"$(nostromo completion)\""
 )
 
 var (
-	startupFilenames   = []string{".profile", ".bash_profile", ".bashrc", ".zshrc"}
-	preferredFilenames = []string{".bashrc", ".zshrc"}
+	startupFilenames = []string{".profile", ".bash_profile", ".bashrc", ".zshrc"}
+	preferredFilenames	 = []string{".bashrc", ".zshrc"}
 )
 
 type startupFile struct {
-	path           string
-	mode           os.FileMode
-	content        string
+	path					 string
+	mode					 os.FileMode
+	content				 string
 	updatedContent string
-	commands       map[string]*model.Command
-	preferred      bool
-	pristine       bool
+	commands			 map[string]*model.Command
+	preferred			 bool
+	pristine			 bool
 }
 
 func isPreferredFilename(filename string) bool {
@@ -91,7 +91,17 @@ func findStartupFile(name string) (string, os.FileMode, error) {
 		return "", 0, err
 	}
 
-	path := filepath.Join(home, name)
+	// zsh doesn't always have a ~/.zshrc file, and if it doesn't,
+  // it does have a $ZDOTDIR/.zshrc
+  // https://wiki.archlinux.org/index.php/Zsh#Startup.2FShutdown_files
+	zdotDir := os.Getenv("ZDOTDIR")
+	var path string
+	if zdotDir != "" {
+		path = filepath.Join(zdotDir, name)
+	} else {
+		path = filepath.Join(home, name)
+	}
+
 	info, err := os.Stat(path)
 	if err != nil {
 		return "", 0, err
@@ -123,9 +133,9 @@ func parseStartupFile(path string, mode os.FileMode) (*startupFile, error) {
 
 func newStartupFile(path, content string, mode os.FileMode) *startupFile {
 	return &startupFile{
-		path:      path,
-		mode:      mode,
-		content:   content,
+		path:			 path,
+		mode:			 mode,
+		content:	 content,
 		commands:  map[string]*model.Command{},
 		preferred: isPreferredFilename(path),
 	}


### PR DESCRIPTION
This change allows the startup file lookup to succeed in case a user has
specified an alternative base directory for their zsh startup files.

In case the `ZDOTDIR` environment variable is set, lookups for zsh
config files use that as a base instead of home[1]. This change replicates
that behaviour.

[1] https://wiki.archlinux.org/index.php/Zsh#Startup.2FShutdown_files