### PR TITLE
Fix shell var functionality with replacement util call

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -237,7 +237,7 @@ func fakeManifest() *model.Manifest {
 func TestGetBaseDir(t *testing.T) {
 	tests := []struct {
 		name string
-		env string
+		env  string
 		want string
 	}{
 		{"default", "", "~/.nostromo"},

--- a/model/command.go
+++ b/model/command.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"fmt"
+	"github.com/pokanop/nostromo/stringutil"
 	"github.com/spf13/cobra"
 	"sort"
 	"strings"
@@ -217,23 +218,22 @@ func (c *Command) executionString(args []string) string {
 	} else {
 		cmd = c.expand()
 	}
-	subs := []string{}
+	var subs []string
 	for _, arg := range args {
 		subs = append(subs, c.substitute(arg))
 	}
-
-	return strings.TrimSpace(fmt.Sprintf("%s %s", cmd, strings.Join(subs, " ")))
+	return stringutil.ReplaceShellVars(cmd, subs)
 }
 
 func (c *Command) expand() string {
-	cmds := []string{}
+	var cmds []string
 	c.reverseWalk(func(cmd *Command, stop *bool) {
 		val := cmd.effectiveCommand()
 		if len(val) > 0 {
 			cmds = append(cmds, val)
 		}
 	})
-	return strings.Join(reversed(cmds), " ")
+	return strings.Join(stringutil.ReversedStrings(cmds), " ")
 }
 
 func (c *Command) substitute(arg string) string {
@@ -337,18 +337,6 @@ func (c *Command) commandList() []string {
 	}
 	sort.Strings(cmds)
 	return cmds
-}
-
-func reversed(strs []string) []string {
-	if strs == nil {
-		return nil
-	}
-
-	r := []string{}
-	for i := len(strs) - 1; i >= 0; i-- {
-		r = append(r, strs[i])
-	}
-	return r
 }
 
 func joinedSubs(subMap map[string]*Substitution) string {

--- a/model/command_test.go
+++ b/model/command_test.go
@@ -257,26 +257,6 @@ func TestWalk(t *testing.T) {
 	}
 }
 
-func TestReversed(t *testing.T) {
-	tests := []struct {
-		name     string
-		strs     []string
-		expected []string
-	}{
-		{"nil strs", nil, nil},
-		{"empty strs", []string{}, []string{}},
-		{"valid strs", []string{"a", "b", "c"}, []string{"c", "b", "a"}},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			if actual := reversed(test.strs); !reflect.DeepEqual(actual, test.expected) {
-				t.Errorf("expected: %s, actual: %s", test.expected, actual)
-			}
-		})
-	}
-}
-
 func TestBuild(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/stringutil/stringutil.go
+++ b/stringutil/stringutil.go
@@ -1,6 +1,9 @@
 package stringutil
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 // SanitizeArgs expands all args by spaces and returns a slice.
 func SanitizeArgs(args []string) []string {
@@ -20,4 +23,33 @@ func SanitizeArgs(args []string) []string {
 // ContainsCaseInsensitive checks if a string is a substring regardless of case.
 func ContainsCaseInsensitive(s, substr string) bool {
 	return strings.Contains(strings.ToLower(s), strings.ToLower(substr))
+}
+
+// ReversedStrings returns a slice of reversed strings.
+func ReversedStrings(strs []string) []string {
+	if strs == nil {
+		return nil
+	}
+
+	r := []string{}
+	for i := len(strs) - 1; i >= 0; i-- {
+		r = append(r, strs[i])
+	}
+	return r
+}
+
+// ReplaceShellVars swaps command args like $1 and returns the result.
+func ReplaceShellVars(cmd string, args []string) string {
+	// Deal with $1 - $N for now, not sure if we need to deal with or how
+	// to handle $#, $@, $*, $!, $$, and $?
+	count := 0
+	for _, arg := range args {
+		shellVar := fmt.Sprintf("$%d", count+1)
+		if !strings.Contains(cmd, shellVar) {
+			break
+		}
+		count += 1
+		cmd = strings.ReplaceAll(cmd, shellVar, arg)
+	}
+	return strings.TrimSpace(fmt.Sprintf("%s %s", cmd, strings.Join(args[count:], " ")))
 }

--- a/stringutil/stringutil_test.go
+++ b/stringutil/stringutil_test.go
@@ -55,3 +55,51 @@ func TestSanitizeArgs(t *testing.T) {
 		})
 	}
 }
+
+func TestReversed(t *testing.T) {
+	tests := []struct {
+		name     string
+		strs     []string
+		expected []string
+	}{
+		{"nil strs", nil, nil},
+		{"empty strs", []string{}, []string{}},
+		{"valid strs", []string{"a", "b", "c"}, []string{"c", "b", "a"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if actual := ReversedStrings(test.strs); !reflect.DeepEqual(actual, test.expected) {
+				t.Errorf("expected: %s, actual: %s", test.expected, actual)
+			}
+		})
+	}
+}
+
+func TestReplaceShellVars(t *testing.T) {
+	type args struct {
+		cmd  string
+		args []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{"nil cmd and args", args{"", nil}, ""},
+		{"nil args", args{"cmd", nil}, "cmd"},
+		{"empty args", args{"cmd", []string{}}, "cmd"},
+		{"no shell vars", args{"cmd", []string{"arg1", "arg2"}}, "cmd arg1 arg2"},
+		{"shell vars", args{"cmd $1 $2", []string{"arg1", "arg2"}}, "cmd arg1 arg2"},
+		{"more shell vars", args{"cmd $1 $2 $3", []string{"arg1", "arg2"}}, "cmd arg1 arg2 $3"},
+		{"less shell vars", args{"cmd $1 $2", []string{"arg1", "arg2", "arg3"}}, "cmd arg1 arg2 arg3"},
+		{"shell vars no space", args{"cmd $1foo$2bar", []string{"arg1", "arg2", "arg3"}}, "cmd arg1fooarg2bar arg3"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ReplaceShellVars(tt.args.cmd, tt.args.args); got != tt.want {
+				t.Errorf("ReplaceShellVars() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change replaces shell vars from a command before returning the evaluation. It only deals with $1 - $N vars and allows them to be used in aliases.

Moves some functions around and add unit tests.

Closes #5 