### PR TITLE
Add update command to root

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,9 @@
 MIT License
 
-Copyright (c) 2019 Pokanop Apps
+Copyright (c) 2022 Pokanop Apps LLC
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/cmd/addcmd.go
+++ b/cmd/addcmd.go
@@ -26,9 +26,9 @@ var addcmdCmd = &cobra.Command{
 A key path is a '.' delimited string, e.g., "key.path" which represents
 the alias which can be run as "key path" for the actual command provided.
 
-This will create appropriate command scopes for all levels in
-the provided key path. A command scope can a tree of sub commands
-and substitutions.
+This will create appropriate command scopes for all levels in the provided
+key path. A command scope can contain a tree of sub commands and 
+substitutions.
 
 A command's mode indicates how it will be executed. By default, nostromo
 concatenates parent and child commands along the tree. There are 3 modes
@@ -46,7 +46,7 @@ You can set using -m or --mode when adding a command or globally using:
 		if len(args) > 1 {
 			name = args[1]
 		}
-		os.Exit(task.AddCommand(args[0], name, description, code, language, aliasOnly, mode))
+		os.Exit(task.AddCommand(args[0], name, description, code, language, aliasOnly, mode, false))
 	},
 }
 

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/pokanop/nostromo/task"
+	"github.com/spf13/cobra"
+)
+
+// updateCmd represents the update command
+var updateCmd = &cobra.Command{
+	Use:   "update [key.path] [command] [options]",
+	Short: "Update a command in nostromo manifest",
+	Long: `Update a command in nostromo manifest for a given key path.
+	A key path is a '.' delimited string, e.g., "key.path" which represents
+	the alias which can be run as "key path" for the actual command provided.
+	
+	This will update appropriate command scopes for all levels in the provided
+	key path. A command scope can contain a tree of sub commands and 
+	substitutions.
+	
+	A command's mode indicates how it will be executed. By default, nostromo
+	concatenates parent and child commands along the tree. There are 3 modes
+	available to commands:
+	
+		concatenate  Concatenate this command with subcommands exactly as defined
+		independent  Execute this command with subcommands using ';' to separate
+		exclusive    Execute this and only this command ignoring parent commands
+	
+	You can set using -m or --mode when adding a command or globally using:
+		nostromo manifest set mode <mode>`,
+	Args: addCmdArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		var name string
+		if len(args) > 1 {
+			name = args[1]
+		}
+		os.Exit(task.AddCommand(args[0], name, description, code, language, aliasOnly, mode, true))
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(updateCmd)
+
+	// Flags
+	updateCmd.Flags().StringVarP(&description, "description", "d", "", "Description of the command to update")
+	updateCmd.Flags().StringVarP(&code, "code", "c", "", "Code snippet to run for this command")
+	updateCmd.Flags().StringVarP(&language, "language", "l", "", "Language of code snippet (e.g., ruby, python, perl, js)")
+	updateCmd.Flags().BoolVarP(&aliasOnly, "alias-only", "a", false, "Add shell alias only, not a nostromo command")
+	updateCmd.Flags().StringVarP(&mode, "mode", "m", "", "Set the mode for the command (concatenate, independent, exclusive)")
+}

--- a/main.go
+++ b/main.go
@@ -1,23 +1,3 @@
-// Copyright © 2019 Sahel Jalal <sahel.jalal@icloud.com>
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
-
 package main
 
 import "github.com/pokanop/nostromo/cmd"

--- a/task/task.go
+++ b/task/task.go
@@ -1,6 +1,8 @@
 package task
 
 import (
+	"strings"
+
 	"github.com/pokanop/nostromo/config"
 	"github.com/pokanop/nostromo/log"
 	"github.com/pokanop/nostromo/model"
@@ -11,7 +13,6 @@ import (
 	"github.com/pokanop/nostromo/version"
 	"github.com/shivamMg/ppds/tree"
 	"github.com/spf13/cobra"
-	"strings"
 )
 
 var ver *version.Info
@@ -247,7 +248,7 @@ func AddInteractive() int {
 		}
 		log.Highlight("\nCreating command...\n")
 
-		return AddCommand(keypath, cmd, description, snippet, language, aliasOnly, mode)
+		return AddCommand(keypath, cmd, description, snippet, language, aliasOnly, mode, false)
 	}
 
 	log.Regularf("A key path is a dot '.' delimited path to where you want to add your command.\n")
@@ -267,13 +268,18 @@ func AddInteractive() int {
 }
 
 // AddCommand to the manifest
-func AddCommand(keyPath, command, description, code, language string, aliasOnly bool, mode string) int {
+func AddCommand(keyPath, command, description, code, language string, aliasOnly bool, mode string, update bool) int {
 	cfg := checkConfig()
 	if cfg == nil {
 		return -1
 	}
 
 	m := cfg.Manifest()
+
+	if update && m.Find(keyPath) == nil {
+		log.Error("no matching command found to update")
+		return -1
+	}
 
 	snippet := &model.Code{
 		Language: language,


### PR DESCRIPTION
Resolves #22 

New `update` command just routes to `add cmd` but is more clear for users. Since add already handled updates it's just duplicated functionality but with more clear intent. Supports the same options as add.