### PR TITLE
Manifest backup functionality

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -1,9 +1,10 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/pokanop/nostromo/task"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 // getCmd represents the get command
@@ -14,8 +15,9 @@ var getCmd = &cobra.Command{
 Nostromo config items are saved in the manifest.
 
 Use this command to get keys to examine these settings:
-verbose: true | false
-aliasesOnly: true | false`,
+verbose: boolean
+aliasesOnly: boolean
+backupCount: number`,
 	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		os.Exit(task.GetConfig(args[0]))

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -1,9 +1,10 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/pokanop/nostromo/task"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 // setCmd represents the set command
@@ -14,11 +15,12 @@ var setCmd = &cobra.Command{
 Nostromo config items are saved in the manifest.
 
 Use this command to set values for these settings:
-  verbose: true | false
-  aliasesOnly: true | false
-  mode: concatenate | independent | exclusive`,
+  verbose: boolean
+  aliasesOnly: boolean
+  mode: concatenate | independent | exclusive
+  backupCount: number`,
 	Args:      cobra.MinimumNArgs(2),
-	ValidArgs: []string{"verbose", "aliasesOnly", "mode"},
+	ValidArgs: []string{"verbose", "aliasesOnly", "mode", "backupCount"},
 	Run: func(cmd *cobra.Command, args []string) {
 		os.Exit(task.SetConfig(args[0], args[1]))
 	},

--- a/config/config.go
+++ b/config/config.go
@@ -228,7 +228,7 @@ func (c *Config) Backup() error {
 	}
 
 	// Copy existing manifest to backup path
-	ts := fmt.Sprintf("%d", time.Now().UnixMilli())
+	ts := fmt.Sprintf("%d", int64(time.Nanosecond)*time.Now().UnixNano()/int64(time.Millisecond))
 	basename := strings.TrimSuffix(DefaultManifestFile, filepath.Ext(DefaultManifestFile))
 	destinationFile := filepath.Join(backupDir, basename+"_"+ts+".yaml")
 	sourceFile := pathutil.Abs(GetConfigPath())

--- a/config/config.go
+++ b/config/config.go
@@ -5,8 +5,12 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
+	"strings"
+	"time"
 
+	"github.com/pokanop/nostromo/log"
 	"github.com/pokanop/nostromo/model"
 	"github.com/pokanop/nostromo/pathutil"
 	"gopkg.in/yaml.v2"
@@ -16,6 +20,7 @@ import (
 const (
 	DefaultManifestFile = "manifest.yaml"
 	DefaultBaseDir      = "~/.nostromo"
+	DefaultBackupsDir   = "backups"
 )
 
 // Config manages working with nostromo configuration files
@@ -61,7 +66,12 @@ func Parse(path string) (*Config, error) {
 		return nil, err
 	}
 
-	var m *model.Manifest
+	// Initialize manifest with some defaults
+	m := &model.Manifest{
+		Config: &model.Config{
+			BackupCount: 10,
+		},
+	}
 	ext := filepath.Ext(path)
 	if ext == ".yaml" {
 		err = yaml.Unmarshal(b, &m)
@@ -89,6 +99,10 @@ func (c *Config) Manifest() *model.Manifest {
 
 // Save nostromo config to file
 func (c *Config) Save() error {
+	return c.save(true)
+}
+
+func (c *Config) save(backup bool) error {
 	if len(c.path) == 0 {
 		return fmt.Errorf("invalid path to save")
 	}
@@ -108,6 +122,13 @@ func (c *Config) Save() error {
 
 	if err != nil {
 		return err
+	}
+
+	// Save backup if requested
+	if backup {
+		if err = c.Backup(); err != nil {
+			return err
+		}
 	}
 
 	err = ioutil.WriteFile(pathutil.Abs(c.path), b, 0644)
@@ -150,6 +171,8 @@ func (c *Config) Get(key string) string {
 		return strconv.FormatBool(c.manifest.Config.AliasesOnly)
 	case "mode":
 		return c.manifest.Config.Mode.String()
+	case "backupCount":
+		return strconv.FormatInt(int64(c.manifest.Config.BackupCount), 10)
 	}
 	return "key not found"
 }
@@ -177,6 +200,80 @@ func (c *Config) Set(key, value string) error {
 		}
 		c.manifest.Config.Mode = model.ModeFromString(value)
 		return nil
+	case "backupCount":
+		count, err := strconv.ParseInt(value, 10, 0)
+		if err != nil {
+			return err
+		}
+		c.manifest.Config.BackupCount = int(count)
+		return nil
 	}
 	return fmt.Errorf("key not found")
+}
+
+// Backup a manifest based on timestamp
+func (c *Config) Backup() error {
+	// Before saving backup, prune old files
+	c.pruneBackups()
+
+	// Create backups under base dir in a folder
+	backupDir, err := ensureBackupDir()
+	if err != nil {
+		return err
+	}
+
+	// Copy existing manifest to backup path
+	ts := time.Now().UTC().Format("20060102150405")
+	basename := strings.TrimSuffix(DefaultManifestFile, filepath.Ext(DefaultManifestFile))
+	destinationFile := filepath.Join(backupDir, basename+"_"+ts+".yaml")
+	sourceFile := pathutil.Abs(GetConfigPath())
+
+	input, err := ioutil.ReadFile(sourceFile)
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(destinationFile, input, 0644)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Config) pruneBackups() {
+	backupDir, err := ensureBackupDir()
+	if err != nil {
+		return
+	}
+
+	// Read all files, sort by timestamp, and drop items > max count
+	files, err := ioutil.ReadDir(backupDir)
+	if err != nil {
+		log.Warningf("unable to read backup dir: %s\n", err)
+		return
+	}
+
+	sort.SliceStable(files, func(i, j int) bool {
+		return files[i].ModTime().After(files[j].ModTime())
+	})
+
+	// Add one more to backup count since a new backup will be created
+	maxCount := c.manifest.Config.BackupCount - 1
+	if maxCount > 0 && len(files) > maxCount {
+		for _, file := range files[maxCount:] {
+			filename := filepath.Join(backupDir, file.Name())
+			if err := os.Remove(filename); err != nil {
+				log.Warningf("failed to prune backup file %s: %s\n", filename, err)
+			}
+		}
+	}
+}
+
+func ensureBackupDir() (string, error) {
+	backupDir := filepath.Join(DefaultBaseDir, DefaultBackupsDir)
+	if err := pathutil.EnsurePath(backupDir); err != nil {
+		return "", err
+	}
+	return pathutil.Abs(backupDir), nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,12 +1,22 @@
 package config
 
 import (
+	"io/ioutil"
 	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/pokanop/nostromo/model"
 )
+
+func TestGetConfigPath(t *testing.T) {
+	expected := "~/.nostromo/manifest.yaml"
+	if actual := GetConfigPath(); actual != expected {
+		t.Errorf("wrong config path, expected: %s, actual: %s", expected, actual)
+	}
+}
 
 func TestParse(t *testing.T) {
 	tests := []struct {
@@ -130,6 +140,7 @@ func TestGet(t *testing.T) {
 		{"verbose", "verbose", "true"},
 		{"aliasesOnly", "aliasesOnly", "true"},
 		{"mode", "mode", "concatenate"},
+		{"backupCount", "backupCount", "10"},
 	}
 
 	for _, test := range tests {
@@ -164,6 +175,9 @@ func TestSet(t *testing.T) {
 		{"mode independent", "mode", "independent", false, "independent"},
 		{"mode exclusive", "mode", "exclusive", false, "exclusive"},
 		{"mode invalid", "mode", "invalid", true, ""},
+		{"backupCount empty", "backupCount", "", true, ""},
+		{"backupCount 5", "backupCount", "5", false, "5"},
+		{"backupCount 100", "backupCount", "100", false, "100"},
 	}
 
 	for _, test := range tests {
@@ -252,6 +266,61 @@ func TestGetBaseDir(t *testing.T) {
 
 			if got := GetBaseDir(); got != tt.want {
 				t.Errorf("GetBaseDir() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBackup(t *testing.T) {
+	tests := []struct {
+		name        string
+		baseDir     string
+		backupCount int
+		expErr      bool
+	}{
+		{"invalid path", "/does/not/exist", 1, true},
+		{"valid path", "/tmp", 1, false},
+		{"no backups", "/tmp", 0, false},
+		{"some backups", "/tmp", 5, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Setenv("NOSTROMO_HOME", tt.baseDir)
+
+			c, err := Parse("../testdata/manifest.yaml")
+			if err != nil {
+				t.Errorf("failed to parse manifest: %s", err)
+			}
+
+			if tt.expErr == false {
+				c.path = filepath.Join(tt.baseDir, "manifest.yaml")
+				err = c.save(false)
+				if err != nil {
+					t.Errorf("failed to save manifest: %s", err)
+				}
+			}
+
+			c.manifest.Config.BackupCount = tt.backupCount
+			err = c.Backup()
+			if err != nil {
+				if tt.expErr == true {
+					return
+				}
+				t.Errorf("failed to backup: %s", err)
+			}
+
+			for i := 0; i < 9; i++ {
+				time.Sleep(10 * time.Millisecond)
+				c.Backup()
+			}
+
+			backupDir, err := ensureBackupDir()
+			files, err := ioutil.ReadDir(backupDir)
+			if err != nil {
+				t.Errorf("could not read backup dir: %s", err)
+			}
+			if len(files) != tt.backupCount {
+				t.Errorf("expected %d backup files but got %d", tt.backupCount, len(files))
 			}
 		})
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -242,13 +242,6 @@ func TestFields(t *testing.T) {
 	}
 }
 
-func fakeManifest() *model.Manifest {
-	m := model.NewManifest()
-	m.AddCommand("one.two.three", "command", "", &model.Code{}, false, "concatenate")
-	m.AddSubstitution("one.two", "name", "alias")
-	return m
-}
-
 func TestGetBaseDir(t *testing.T) {
 	tests := []struct {
 		name string
@@ -324,4 +317,11 @@ func TestBackup(t *testing.T) {
 			}
 		})
 	}
+}
+
+func fakeManifest() *model.Manifest {
+	m := model.NewManifest()
+	m.AddCommand("one.two.three", "command", "", &model.Code{}, false, "concatenate")
+	m.AddSubstitution("one.two", "name", "alias")
+	return m
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -57,7 +57,7 @@ func TestSave(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			c := NewConfig(test.path, test.manifest)
-			err := c.Save()
+			err := c.save(false)
 			if test.expErr && err == nil {
 				t.Errorf("expected error but got none")
 			} else if !test.expErr && err != nil {
@@ -83,7 +83,7 @@ func TestDelete(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			c := NewConfig(test.path, test.manifest)
 			if test.manifest != nil {
-				err := c.Save()
+				err := c.save(false)
 				if err != nil {
 					t.Errorf("unable to save temporary manifest: %s", err)
 				}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -189,7 +189,7 @@ func TestKeys(t *testing.T) {
 		config   *Config
 		expected []string
 	}{
-		{"keys", NewConfig("path", fakeManifest()), []string{"verbose", "aliasesOnly", "mode"}},
+		{"keys", NewConfig("path", fakeManifest()), []string{"verbose", "aliasesOnly", "mode", "backupCount"}},
 	}
 
 	for _, test := range tests {
@@ -214,6 +214,7 @@ func TestFields(t *testing.T) {
 				"verbose":     false,
 				"aliasesOnly": false,
 				"mode":        model.ConcatenateMode.String(),
+				"backupCount": 10,
 			},
 		},
 	}

--- a/model/config.go
+++ b/model/config.go
@@ -5,11 +5,19 @@ type Config struct {
 	Verbose     bool `json:"verbose"`
 	AliasesOnly bool `json:"aliasesOnly"`
 	Mode        Mode `json:"mode"`
+	BackupCount int  `json:"backupCount"`
+}
+
+// Create a new config model with default values
+func NewConfig() *Config {
+	return &Config{
+		BackupCount: 10,
+	}
 }
 
 // Keys as ordered list of fields for logging
 func (c *Config) Keys() []string {
-	return []string{"verbose", "aliasesOnly", "mode"}
+	return []string{"verbose", "aliasesOnly", "mode", "backupCount"}
 }
 
 // Fields interface for logging
@@ -18,5 +26,6 @@ func (c *Config) Fields() map[string]interface{} {
 		"verbose":     c.Verbose,
 		"aliasesOnly": c.AliasesOnly,
 		"mode":        c.Mode.String(),
+		"backupCount": c.BackupCount,
 	}
 }

--- a/model/config_test.go
+++ b/model/config_test.go
@@ -5,13 +5,20 @@ import (
 	"testing"
 )
 
+func TestNewConfig(t *testing.T) {
+	c := NewConfig()
+	if c.BackupCount != 10 {
+		t.Errorf("unexpected default values for config")
+	}
+}
+
 func TestConfigKeys(t *testing.T) {
 	tests := []struct {
 		name     string
 		manifest *Manifest
 		expected []string
 	}{
-		{"keys", fakeManifest(1, 1), []string{"verbose", "aliasesOnly", "mode"}},
+		{"keys", fakeManifest(1, 1), []string{"verbose", "aliasesOnly", "mode", "backupCount"}},
 	}
 
 	for _, test := range tests {
@@ -36,6 +43,7 @@ func TestConfigFields(t *testing.T) {
 				"verbose":     true,
 				"aliasesOnly": false,
 				"mode":        "concatenate",
+				"backupCount": 10,
 			},
 		},
 	}

--- a/model/manifest.go
+++ b/model/manifest.go
@@ -22,7 +22,7 @@ type Manifest struct {
 func NewManifest() *Manifest {
 	return &Manifest{
 		Version:  "1.0",
-		Config:   &Config{},
+		Config:   NewConfig(),
 		Commands: map[string]*Command{},
 	}
 }

--- a/model/manifest_test.go
+++ b/model/manifest_test.go
@@ -1,13 +1,14 @@
 package model
 
 import (
-	"github.com/shivamMg/ppds/tree"
 	"io/ioutil"
 	"os"
 	"reflect"
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/shivamMg/ppds/tree"
 
 	"github.com/pokanop/nostromo/keypath"
 	"github.com/pokanop/nostromo/pathutil"
@@ -316,7 +317,7 @@ func TestManifestData(t *testing.T) {
 		fields fields
 		want   interface{}
 	}{
-		{"data", fields{"1.0", &Config{true, true, ConcatenateMode}, map[string]*Command{"foo": {}}}, "manifest"},
+		{"data", fields{"1.0", &Config{true, true, ConcatenateMode, 10}, map[string]*Command{"foo": {}}}, "manifest"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -347,7 +348,7 @@ func TestManifestChildren(t *testing.T) {
 		fields fields
 		want   []tree.Node
 	}{
-		{"children", fields{"1.0", &Config{true, true, ConcatenateMode}, commands}, []tree.Node{commands["foo"], commands["bar"]}},
+		{"children", fields{"1.0", &Config{true, true, ConcatenateMode, 10}, commands}, []tree.Node{commands["foo"], commands["bar"]}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -3,6 +3,8 @@ package shell
 import (
 	"reflect"
 	"testing"
+
+	"github.com/pokanop/nostromo/model"
 )
 
 func TestValidLanguages(t *testing.T) {
@@ -74,4 +76,41 @@ func TestEvalString(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestShellWrapperFunc(t *testing.T) {
+	if shellWrapperFunc() != `__nostromo_cmd() { command nostromo $*; }
+nostromo() { __nostromo_cmd $* && eval "$(__nostromo_cmd completion)"; }` {
+		t.Errorf("shell wrapper func not as expected")
+	}
+}
+
+// func TestShellAliasFuncs(t *testing.T) {
+// 	tests := []struct {
+// 		name     string
+// 		manifest *model.Manifest
+// 		expected string
+// 	}{
+// 		{"no alias", fakeManifest(false), "\none() { eval $(__nostromo_cmd eval one \"$*\"); }\ntwo() { eval $(__nostromo_cmd eval two \"$*\"); }\n"},
+// 		{"alias only", fakeManifest(true), ""},
+// 	}
+
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			actual := shellAliasFuncs(tt.manifest)
+// 			fmt.Printf("<start>%s<end>", actual)
+// 			if tt.expected != actual {
+// 				t.Errorf("shell alias funcs incorrect expected: %s, actual: %s", tt.expected, actual)
+// 			}
+// 		})
+// 	}
+// }
+
+func fakeManifest(aliasOnly bool) *model.Manifest {
+	m := model.NewManifest()
+	m.Config.AliasesOnly = aliasOnly
+	m.AddCommand("one.two.three", "command", "", &model.Code{}, false, "concatenate")
+	m.AddSubstitution("one.two", "name", "alias")
+	m.AddCommand("two", "command", "", &model.Code{}, false, "concatenate")
+	return m
 }

--- a/testdata/manifest.json
+++ b/testdata/manifest.json
@@ -3,7 +3,8 @@
   "config": {
     "verbose": true,
     "aliasesOnly": false,
-    "mode": 0
+    "mode": 0,
+    "backupCount": 10
   },
   "commands": {
     "0-one-alias": {

--- a/testdata/manifest.yaml
+++ b/testdata/manifest.yaml
@@ -3,6 +3,7 @@ config:
   verbose: true
   aliasesonly: false
   mode: 0
+  backupcount: 10
 commands:
   0-one-alias:
     keypath: 0-one-alias


### PR DESCRIPTION
Resolves #21 

This change introduces manifest backups in the nostromo home folder. It does not move profile backups but provides support to backup files and prune automatically on every manifest change.

Config setting added for `backupCount` as well.