### PR TITLE
Manifest versioning support

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,14 +40,11 @@ func Execute() {
 
 // SetVersion to inject version info
 func SetVersion(v, c, d string) {
-	ver = &version.Info{
-		SemVer:    v,
-		GitCommit: c,
-		BuildDate: d,
-	}
+	ver = version.NewInfo(v, c, d)
 
-	// Update task package
+	// Update dependent packages
 	task.SetVersion(ver)
+	config.SetVersion(ver)
 }
 
 func init() {

--- a/config/config.go
+++ b/config/config.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pokanop/nostromo/log"
 	"github.com/pokanop/nostromo/model"
 	"github.com/pokanop/nostromo/pathutil"
+	"github.com/pokanop/nostromo/version"
 	"gopkg.in/yaml.v2"
 )
 
@@ -22,6 +23,13 @@ const (
 	DefaultBaseDir      = "~/.nostromo"
 	DefaultBackupsDir   = "backups"
 )
+
+var ver *version.Info
+
+// SetVersion should be called before any task to ensure manifest is updated
+func SetVersion(v *version.Info) {
+	ver = v
+}
 
 // Config manages working with nostromo configuration files
 // The file format is YAML this just provides convenience around converting
@@ -74,7 +82,11 @@ func Parse(path string) (*Config, error) {
 	}
 	ext := filepath.Ext(path)
 	if ext == ".yaml" {
-		err = yaml.Unmarshal(b, &m)
+		// Attempt to parse legacy manifest versions first
+		m = parseV0(b)
+		if m == nil {
+			err = yaml.Unmarshal(b, &m)
+		}
 	} else {
 		return nil, fmt.Errorf("invalid file format: %s", ext)
 	}
@@ -110,6 +122,9 @@ func (c *Config) save(backup bool) error {
 	if c.manifest == nil {
 		return fmt.Errorf("manifest is nil")
 	}
+
+	// Update version
+	c.manifest.Version.Update(ver)
 
 	var b []byte
 	var err error
@@ -284,4 +299,17 @@ func ensureBackupDir() (string, error) {
 		return "", err
 	}
 	return pathutil.Abs(backupDir), nil
+}
+
+func parseV0(data []byte) *model.Manifest {
+	var prev *model.ManifestV0
+	if err := yaml.Unmarshal(data, &prev); err != nil {
+		return nil
+	}
+
+	// Create new manifest with current version and migrate data
+	m := model.NewManifest(ver)
+	m.Config = prev.Config
+	m.Commands = prev.Commands
+	return m
 }

--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -247,6 +248,11 @@ func (c *Config) Backup() error {
 	basename := strings.TrimSuffix(DefaultManifestFile, filepath.Ext(DefaultManifestFile))
 	destinationFile := filepath.Join(backupDir, basename+"_"+ts+".yaml")
 	sourceFile := pathutil.Abs(GetConfigPath())
+
+	// Check if manifest exists
+	if _, err := os.Stat(sourceFile); errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
 
 	input, err := ioutil.ReadFile(sourceFile)
 	if err != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -321,17 +321,10 @@ func TestBackup(t *testing.T) {
 }
 
 func fakeManifest() *model.Manifest {
-	m := model.NewManifest()
+	m := model.NewManifest(&version.Info{})
 	m.AddCommand("one.two.three", "command", "", &model.Code{}, false, "concatenate")
 	m.AddSubstitution("one.two", "name", "alias")
 	return m
-}
-
-func fakeManifest() *model.Manifest {
-    m := model.NewManifest(&version.Info{})
-    m.AddCommand("one.two.three", "command", "", &model.Code{}, false, "concatenate")
-    m.AddSubstitution("one.two", "name", "alias")
-    return m
 }
 
 func init() {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -270,12 +270,14 @@ func TestBackup(t *testing.T) {
 		name        string
 		baseDir     string
 		backupCount int
+		copy        bool
 		expErr      bool
 	}{
-		{"invalid path", "/does/not/exist", 1, true},
-		{"valid path", "/tmp", 1, false},
-		{"no backups", "/tmp", 0, false},
-		{"some backups", "/tmp", 5, false},
+		{"invalid path", "/does/not/exist", 1, false, true},
+		{"valid path", "/tmp", 1, true, false},
+		{"missing manifest", "/tmp", 1, false, false},
+		{"no backups", "/tmp", 0, true, false},
+		{"some backups", "/tmp", 5, true, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -286,7 +288,7 @@ func TestBackup(t *testing.T) {
 				t.Errorf("failed to parse manifest: %s", err)
 			}
 
-			if tt.expErr == false {
+			if tt.copy == true {
 				c.path = filepath.Join(tt.baseDir, "manifest.yaml")
 				err = c.save(false)
 				if err != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/pokanop/nostromo/model"
+	"github.com/pokanop/nostromo/version"
 )
 
 func TestGetConfigPath(t *testing.T) {
@@ -324,4 +325,15 @@ func fakeManifest() *model.Manifest {
 	m.AddCommand("one.two.three", "command", "", &model.Code{}, false, "concatenate")
 	m.AddSubstitution("one.two", "name", "alias")
 	return m
+}
+
+func fakeManifest() *model.Manifest {
+    m := model.NewManifest(&version.Info{})
+    m.AddCommand("one.two.three", "command", "", &model.Code{}, false, "concatenate")
+    m.AddSubstitution("one.two", "name", "alias")
+    return m
+}
+
+func init() {
+	SetVersion(version.NewInfo("", "", ""))
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/pokanop/nostromo
 go 1.12
 
 require (
+	github.com/google/uuid v1.3.0
 	github.com/logrusorgru/aurora v0.0.0-20190417123914-21d75270181e
 	github.com/magiconair/properties v1.8.1 // indirect
 	github.com/mattn/go-runewidth v0.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=

--- a/model/manifest.go
+++ b/model/manifest.go
@@ -7,21 +7,28 @@ import (
 
 	"github.com/pokanop/nostromo/keypath"
 	"github.com/pokanop/nostromo/log"
+	"github.com/pokanop/nostromo/version"
 	"github.com/shivamMg/ppds/tree"
 	"gopkg.in/yaml.v2"
 )
 
-// Manifest is the main container for nostromo based commands
-type Manifest struct {
+type ManifestV0 struct {
 	Version  string              `json:"version"`
 	Config   *Config             `json:"config"`
 	Commands map[string]*Command `json:"commands"`
 }
 
+// Manifest is the main container for nostromo based commands
+type Manifest struct {
+	Version  *version.Info       `json:"version"`
+	Config   *Config             `json:"config"`
+	Commands map[string]*Command `json:"commands"`
+}
+
 // NewManifest returns a newly initialized manifest
-func NewManifest() *Manifest {
+func NewManifest(version *version.Info) *Manifest {
 	return &Manifest{
-		Version:  "1.0",
+		Version:  version,
 		Config:   NewConfig(),
 		Commands: map[string]*Command{},
 	}

--- a/model/manifest_test.go
+++ b/model/manifest_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/pokanop/nostromo/keypath"
 	"github.com/pokanop/nostromo/pathutil"
+	"github.com/pokanop/nostromo/version"
 )
 
 func TestManifestAddCommand(t *testing.T) {
@@ -291,7 +292,7 @@ func TestManifestFields(t *testing.T) {
 			"keys",
 			fakeManifest(1, 1),
 			map[string]interface{}{
-				"version":  "1.0",
+				"version":  &version.Info{},
 				"commands": "0-one-alias",
 			},
 		},
@@ -308,7 +309,7 @@ func TestManifestFields(t *testing.T) {
 
 func TestManifestData(t *testing.T) {
 	type fields struct {
-		Version  string
+		Version  *version.Info
 		Config   *Config
 		Commands map[string]*Command
 	}
@@ -317,7 +318,7 @@ func TestManifestData(t *testing.T) {
 		fields fields
 		want   interface{}
 	}{
-		{"data", fields{"1.0", &Config{true, true, ConcatenateMode, 10}, map[string]*Command{"foo": {}}}, "manifest"},
+		{"data", fields{&version.Info{}, &Config{true, true, ConcatenateMode}, map[string]*Command{"foo": {}}}, "manifest"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -339,7 +340,7 @@ func TestManifestChildren(t *testing.T) {
 		"bar": {},
 	}
 	type fields struct {
-		Version  string
+		Version  *version.Info
 		Config   *Config
 		Commands map[string]*Command
 	}
@@ -348,7 +349,7 @@ func TestManifestChildren(t *testing.T) {
 		fields fields
 		want   []tree.Node
 	}{
-		{"children", fields{"1.0", &Config{true, true, ConcatenateMode, 10}, commands}, []tree.Node{commands["foo"], commands["bar"]}},
+		{"children", fields{&version.Info{}, &Config{true, true, ConcatenateMode}, commands}, []tree.Node{commands["foo"], commands["bar"]}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -365,7 +366,7 @@ func TestManifestChildren(t *testing.T) {
 }
 
 func fakeManifest(n, depth int) *Manifest {
-	m := NewManifest()
+	m := NewManifest(&version.Info{})
 	m.Config.Verbose = true
 	for i := 0; i < n; i++ {
 		c := fakeCommandWithPrefix(depth, strconv.Itoa(i)+"-")
@@ -375,7 +376,7 @@ func fakeManifest(n, depth int) *Manifest {
 }
 
 func fakeManifestAliasesOnly(n, depth int) *Manifest {
-	m := NewManifest()
+	m := NewManifest(&version.Info{})
 	m.Config.AliasesOnly = true
 	for i := 0; i < n; i++ {
 		c := fakeCommandWithPrefix(depth, strconv.Itoa(i)+"-")
@@ -385,7 +386,7 @@ func fakeManifestAliasesOnly(n, depth int) *Manifest {
 }
 
 func fakeSimilarManifest(n, depth int) *Manifest {
-	m := NewManifest()
+	m := NewManifest(&version.Info{})
 	for i := 0; i < n; i++ {
 		c := fakeCommand(depth)
 		c.Alias = strconv.Itoa(i) + "-" + c.Alias

--- a/model/manifest_test.go
+++ b/model/manifest_test.go
@@ -318,7 +318,7 @@ func TestManifestData(t *testing.T) {
 		fields fields
 		want   interface{}
 	}{
-		{"data", fields{&version.Info{}, &Config{true, true, ConcatenateMode}, map[string]*Command{"foo": {}}}, "manifest"},
+		{"data", fields{&version.Info{}, &Config{true, true, ConcatenateMode, 10}, map[string]*Command{"foo": {}}}, "manifest"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -349,7 +349,7 @@ func TestManifestChildren(t *testing.T) {
 		fields fields
 		want   []tree.Node
 	}{
-		{"children", fields{&version.Info{}, &Config{true, true, ConcatenateMode}, commands}, []tree.Node{commands["foo"], commands["bar"]}},
+		{"children", fields{&version.Info{}, &Config{true, true, ConcatenateMode, 10}, commands}, []tree.Node{commands["foo"], commands["bar"]}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/pokanop/nostromo/model"
+	"github.com/pokanop/nostromo/version"
 )
 
 func TestValidLanguages(t *testing.T) {
@@ -107,7 +108,7 @@ nostromo() { __nostromo_cmd $* && eval "$(__nostromo_cmd completion)"; }` {
 // }
 
 func fakeManifest(aliasOnly bool) *model.Manifest {
-	m := model.NewManifest()
+	m := model.NewManifest(&version.Info{})
 	m.Config.AliasesOnly = aliasOnly
 	m.AddCommand("one.two.three", "command", "", &model.Code{}, false, "concatenate")
 	m.AddSubstitution("one.two", "name", "alias")

--- a/shell/startupfile_test.go
+++ b/shell/startupfile_test.go
@@ -1,14 +1,15 @@
 package shell
 
 import (
-	"github.com/pokanop/nostromo/model"
 	"os"
 	"reflect"
 	"testing"
+
+	"github.com/pokanop/nostromo/model"
+	"github.com/pokanop/nostromo/version"
 )
 
 func TestStartupFile(t *testing.T) {
-
 	tests := []struct {
 		name        string
 		path        string
@@ -23,12 +24,12 @@ func TestStartupFile(t *testing.T) {
 		{"nil manifest", ".profile", "", nil, false, true, false, true, ""},
 		{"malformed block 1", ".zshrc", "export PATH=/usr/local/bin\nexport FOO=bar\n\n# nostromo [section begin]\neval \"$(nostromo completion)\"\nalias foo='nostromo eval foo \"$*\"'\nalias bar='nostromo eval bar \"$*\"'", makeManifest("foo", "baz"), true, false, true, true, ""},
 		{"malformed block 2", ".zshrc", "export PATH=/usr/local/bin\nexport FOO=bar\n\n# nostromo [section begin]\neval \"$(nostromo completion)\"\nalias foo='nostromo eval foo \"$*\"'\nalias bar='nostromo eval bar \"$*\"'# nostromo [section begin]", makeManifest("foo", "baz"), true, false, true, true, ""},
-		{"empty profile", ".profile", "", model.NewManifest(), false, true, false, false, ""},
-		{"empty bash_profile", ".bash_profile", "", model.NewManifest(), false, true, false, false, ""},
-		{"empty bashrc", ".bashrc", "", model.NewManifest(), true, true, false, false, "\n# nostromo [section begin]\neval \"$(nostromo completion)\"\n# nostromo [section end]\n"},
-		{"empty zshrc", ".zshrc", "", model.NewManifest(), true, true, false, false, "\n# nostromo [section begin]\neval \"$(nostromo completion)\"\n# nostromo [section end]\n"},
-		{"existing non-preferred no commands", ".profile", "export PATH=/usr/local/bin\nexport FOO=bar", model.NewManifest(), false, true, false, false, "export PATH=/usr/local/bin\nexport FOO=bar"},
-		{"existing preferred no commands", ".zshrc", "export PATH=/usr/local/bin\nexport FOO=bar", model.NewManifest(), true, true, false, false, "export PATH=/usr/local/bin\nexport FOO=bar\n# nostromo [section begin]\neval \"$(nostromo completion)\"\n# nostromo [section end]\n"},
+		{"empty profile", ".profile", "", model.NewManifest(&version.Info{}), false, true, false, false, ""},
+		{"empty bash_profile", ".bash_profile", "", model.NewManifest(&version.Info{}), false, true, false, false, ""},
+		{"empty bashrc", ".bashrc", "", model.NewManifest(&version.Info{}), true, true, false, false, "\n# nostromo [section begin]\neval \"$(nostromo completion)\"\n# nostromo [section end]\n"},
+		{"empty zshrc", ".zshrc", "", model.NewManifest(&version.Info{}), true, true, false, false, "\n# nostromo [section begin]\neval \"$(nostromo completion)\"\n# nostromo [section end]\n"},
+		{"existing non-preferred no commands", ".profile", "export PATH=/usr/local/bin\nexport FOO=bar", model.NewManifest(&version.Info{}), false, true, false, false, "export PATH=/usr/local/bin\nexport FOO=bar"},
+		{"existing preferred no commands", ".zshrc", "export PATH=/usr/local/bin\nexport FOO=bar", model.NewManifest(&version.Info{}), true, true, false, false, "export PATH=/usr/local/bin\nexport FOO=bar\n# nostromo [section begin]\neval \"$(nostromo completion)\"\n# nostromo [section end]\n"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -169,7 +170,7 @@ func makeManifest(cmds ...string) *model.Manifest {
 }
 
 func makeManifestLong(match bool, aliasOnly bool, cmds ...string) *model.Manifest {
-	m := model.NewManifest()
+	m := model.NewManifest(&version.Info{})
 	for _, cmd := range cmds {
 		alias := cmd
 		if !match {

--- a/task/task.go
+++ b/task/task.go
@@ -29,7 +29,7 @@ func InitConfig() int {
 	if cfg == nil {
 		baseDir := config.GetBaseDir()
 		configPath := config.GetConfigPath()
-		cfg = config.NewConfig(configPath, model.NewManifest())
+		cfg = config.NewConfig(configPath, model.NewManifest(ver))
 		err := pathutil.EnsurePath(baseDir)
 		if err != nil {
 			log.Error(err)
@@ -65,7 +65,7 @@ func DestroyConfig() int {
 
 	log.Highlight("nostromo config deleted")
 
-	err = shell.Commit(model.NewManifest())
+	err = shell.Commit(model.NewManifest(ver))
 	if err != nil {
 		log.Error(err)
 		return -1
@@ -482,7 +482,6 @@ func checkConfigCommon(quiet bool) *config.Config {
 
 func saveConfig(cfg *config.Config, commit bool) error {
 	m := cfg.Manifest()
-	m.Version = ver.SemVer
 
 	err := cfg.Save()
 	if err != nil {

--- a/testdata/manifest.json
+++ b/testdata/manifest.json
@@ -1,5 +1,10 @@
 {
-  "version": "1.0",
+  "version": {
+    "uuid": "",
+    "semVer": "",
+    "gitCommit": "",
+    "buildDate": ""
+  },
   "config": {
     "verbose": true,
     "aliasesOnly": false,

--- a/testdata/manifest.yaml
+++ b/testdata/manifest.yaml
@@ -1,4 +1,8 @@
-version: "1.0"
+version:
+  uuid: ""
+  semver: ""
+  gitcommit: ""
+  builddate: ""
 config:
   verbose: true
   aliasesonly: false

--- a/version/version.go
+++ b/version/version.go
@@ -1,15 +1,33 @@
 package version
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+)
 
 // Info identifying version information for releases
 type Info struct {
-	SemVer    string
-	GitCommit string
-	BuildDate string
+	UUID      string `json:"uuid"`
+	SemVer    string `json:"semVer"`
+	GitCommit string `json:"gitCommit"`
+	BuildDate string `json:"buildDate"`
+}
+
+// Create a new version info with unique identifier
+func NewInfo(semver string, gitCommit string, buildDate string) *Info {
+	return &Info{uuid.NewString(), semver, gitCommit, buildDate}
 }
 
 // Formatted returns version formatted string
 func (i *Info) Formatted() string {
 	return fmt.Sprintf("&version.Info{SemVer:\"%s\", GitCommit:\"%s\", BuildDate:\"%s\"}", i.SemVer, i.GitCommit, i.BuildDate)
+}
+
+// Update the version info including unique identifier
+func (i *Info) Update(ver *Info) {
+	i.UUID = ver.UUID
+	i.SemVer = ver.SemVer
+	i.GitCommit = ver.GitCommit
+	i.BuildDate = ver.BuildDate
 }

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -1,0 +1,40 @@
+package version
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestNewInfo(t *testing.T) {
+	v := NewInfo("a", "b", "c")
+	if len(v.UUID) == 0 {
+		t.Errorf("version uuid should not be empty")
+	}
+	if v.SemVer != "a" {
+		t.Errorf("version semver expected: %s, actual: %s", "a", v.SemVer)
+	}
+	if v.GitCommit != "b" {
+		t.Errorf("version git commit expected: %s, actual: %s", "b", v.GitCommit)
+	}
+	if v.BuildDate != "c" {
+		t.Errorf("version build date expected: %s, actual: %s", "c", v.BuildDate)
+	}
+}
+
+func TestFormatted(t *testing.T) {
+	v := &Info{"a", "b", "c", "d"}
+	if v.Formatted() != fmt.Sprintf("&version.Info{SemVer:\"%s\", GitCommit:\"%s\", BuildDate:\"%s\"}", v.SemVer, v.GitCommit, v.BuildDate) {
+		t.Errorf("formatted version info incorrect")
+	}
+}
+
+func TestUpdate(t *testing.T) {
+	v1 := NewInfo("a", "b", "c")
+	v2 := NewInfo("d", "e", "f")
+
+	v1.Update(v2)
+	if !reflect.DeepEqual(v1, v2) {
+		t.Errorf("versions should be equal")
+	}
+}


### PR DESCRIPTION
Resolves #24 

Adds a UUID based version to the manifest files. Upgrades from old manifest and keeps backup just in case.
Version includes build information as well as unique id.

Old manifest:
```yaml
version: 0.7.8
config:
  verbose: false
  aliasesonly: false
  mode: 0
commands: {}
```

New manifest:
```yaml
version:
  uuid: ca9e36f6-ca45-4f4c-bc1c-13cbbfeec8d7
  semver: dev
  gitcommit: none
  builddate: unknown
config:
  verbose: false
  aliasesonly: false
  mode: 0
  backupcount: 10
commands: {}
```