### PR TITLE
Disable command subtrees using command flag

### DIFF
--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -1,9 +1,10 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/pokanop/nostromo/task"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 // evalCmd represents the eval command

--- a/model/command.go
+++ b/model/command.go
@@ -2,10 +2,11 @@ package model
 
 import (
 	"fmt"
-	"github.com/pokanop/nostromo/stringutil"
-	"github.com/spf13/cobra"
 	"sort"
 	"strings"
+
+	"github.com/pokanop/nostromo/stringutil"
+	"github.com/spf13/cobra"
 
 	"github.com/pokanop/nostromo/keypath"
 	"github.com/shivamMg/ppds/tree"
@@ -23,6 +24,7 @@ type Command struct {
 	Subs        map[string]*Substitution `json:"subs"`
 	Code        *Code                    `json:"code"`
 	Mode        Mode                     `json:"mode"`
+	Disabled    bool                     `json:"disabled"`
 }
 
 func (c *Command) String() string {
@@ -31,7 +33,7 @@ func (c *Command) String() string {
 
 // Keys as ordered list of fields for logging
 func (c *Command) Keys() []string {
-	return []string{"keypath", "alias", "command", "description", "commands", "substitutions", "code", "mode", "aliasOnly"}
+	return []string{"keypath", "alias", "command", "description", "commands", "substitutions", "code", "mode", "aliasOnly", "disabled"}
 }
 
 // Fields interface for logging
@@ -46,6 +48,7 @@ func (c *Command) Fields() map[string]interface{} {
 		"code":          c.Code.valid(),
 		"mode":          c.Mode.String(),
 		"aliasOnly":     c.AliasOnly,
+		"disabled":      c.Disabled,
 	}
 }
 
@@ -103,6 +106,7 @@ func newCommand(name, alias, description string, code *Code, aliasOnly bool, mod
 		Subs:        map[string]*Substitution{},
 		Code:        code,
 		Mode:        ModeFromString(mode),
+		Disabled:    false,
 	}
 }
 

--- a/model/command.go
+++ b/model/command.go
@@ -343,6 +343,23 @@ func (c *Command) commandList() []string {
 	return cmds
 }
 
+// checkDisabled returns true if this command or any parent node is disabled, and otherwise false
+//
+// Returns command if disabled, and otherwise nil
+func (c *Command) checkDisabled() (bool, *Command) {
+	cmd := c
+	for {
+		if cmd == nil {
+			break
+		}
+		if cmd.Disabled == true {
+			return true, cmd
+		}
+		cmd = cmd.parent
+	}
+	return false, nil
+}
+
 func joinedSubs(subMap map[string]*Substitution) string {
 	subs := []string{}
 	for sub := range subMap {

--- a/model/command_test.go
+++ b/model/command_test.go
@@ -1,10 +1,11 @@
 package model
 
 import (
-	"github.com/shivamMg/ppds/tree"
 	"math"
 	"reflect"
 	"testing"
+
+	"github.com/shivamMg/ppds/tree"
 
 	"github.com/pokanop/nostromo/keypath"
 )
@@ -21,9 +22,9 @@ func TestNewCommand(t *testing.T) {
 		code        *Code
 		expected    *Command
 	}{
-		{"empty alias", "cmd", "", false, "", nil, &Command{nil, "cmd", "cmd", "cmd", false, "", map[string]*Command{}, map[string]*Substitution{}, &Code{}, ConcatenateMode}},
-		{"empty name", "", "alias", false, "", nil, &Command{nil, "alias", "", "alias", false, "", map[string]*Command{}, map[string]*Substitution{}, &Code{}, ConcatenateMode}},
-		{"valid alias", "cmd", "cmd-alias", false, "description", nil, &Command{nil, "cmd-alias", "cmd", "cmd-alias", false, "description", map[string]*Command{}, map[string]*Substitution{}, &Code{}, ConcatenateMode}},
+		{"empty alias", "cmd", "", false, "", nil, &Command{nil, "cmd", "cmd", "cmd", false, "", map[string]*Command{}, map[string]*Substitution{}, &Code{}, ConcatenateMode, false}},
+		{"empty name", "", "alias", false, "", nil, &Command{nil, "alias", "", "alias", false, "", map[string]*Command{}, map[string]*Substitution{}, &Code{}, ConcatenateMode, false}},
+		{"valid alias", "cmd", "cmd-alias", false, "description", nil, &Command{nil, "cmd-alias", "cmd", "cmd-alias", false, "description", map[string]*Command{}, map[string]*Substitution{}, &Code{}, ConcatenateMode, false}},
 	}
 
 	for _, test := range tests {
@@ -312,7 +313,7 @@ func TestKeys(t *testing.T) {
 		command  *Command
 		expected []string
 	}{
-		{"keys", fakeCommand(1), []string{"keypath", "alias", "command", "description", "commands", "substitutions", "code", "mode", "aliasOnly"}},
+		{"keys", fakeCommand(1), []string{"keypath", "alias", "command", "description", "commands", "substitutions", "code", "mode", "aliasOnly", "disabled"}},
 	}
 
 	for _, test := range tests {
@@ -343,6 +344,7 @@ func TestFields(t *testing.T) {
 				"keypath":       "one-alias",
 				"mode":          "concatenate",
 				"aliasOnly":     false,
+				"disabled":      false,
 			},
 		},
 	}

--- a/model/manifest.go
+++ b/model/manifest.go
@@ -167,6 +167,9 @@ func (m *Manifest) ExecutionString(args []string) (string, string, error) {
 			}
 
 			c := cmd.find(keyPath)
+			if disabled, n := c.checkDisabled(); disabled == true {
+				return "", "", fmt.Errorf("command is disabled at %s", n.KeyPath)
+			}
 			return c.Code.Language, c.executionString(args[count:]), nil
 		}
 	}

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -117,8 +117,9 @@ func buildEvalCmd(cmd, language string) string {
 }
 
 func shellWrapperFunc() string {
-	return `__nostromo_cmd() { command nostromo $*; }
-nostromo() { __nostromo_cmd $* && eval "$(__nostromo_cmd completion)"; }`
+	// Sources completion scripts after each command in case something changes
+	return `__nostromo_cmd() { command nostromo "$@"; }
+nostromo() { __nostromo_cmd "$@" && eval "$(__nostromo_cmd completion)"; }`
 }
 
 func shellAliasFuncs(m *model.Manifest) string {
@@ -128,7 +129,10 @@ func shellAliasFuncs(m *model.Manifest) string {
 		if c.AliasOnly {
 			alias = fmt.Sprintf("alias %s='%s'", c.Alias, c.Name)
 		} else {
-			cmd := fmt.Sprintf("__nostromo_cmd eval %s \"$*\"", c.Alias)
+			// This will generate a shell command provided to the completion script
+			// generation. When users run a command, it actually runs evaluates
+			// the result of `nostromo eval` with arguments resolved.
+			cmd := fmt.Sprintf("__nostromo_cmd eval %s \"$@\"", c.Alias)
 			alias = strings.TrimSpace(fmt.Sprintf("%s() { eval $(%s); }", c.Alias, cmd))
 		}
 		aliases = append(aliases, alias)

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -118,7 +118,7 @@ func buildEvalCmd(cmd, language string) string {
 
 func shellWrapperFunc() string {
 	// Sources completion scripts after each command in case something changes
-	return `__nostromo_cmd() { command nostromo "$@"; }
+	return `__nostromo_cmd() { command ./nostromo "$@"; }
 nostromo() { __nostromo_cmd "$@" && eval "$(__nostromo_cmd completion)"; }`
 }
 

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -80,7 +80,7 @@ func TestEvalString(t *testing.T) {
 }
 
 func TestShellWrapperFunc(t *testing.T) {
-	if shellWrapperFunc() != `__nostromo_cmd() { command nostromo "$@"; }
+	if shellWrapperFunc() != `__nostromo_cmd() { command ./nostromo "$@"; }
 nostromo() { __nostromo_cmd "$@" && eval "$(__nostromo_cmd completion)"; }` {
 		t.Errorf("shell wrapper func not as expected")
 	}

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -80,8 +80,8 @@ func TestEvalString(t *testing.T) {
 }
 
 func TestShellWrapperFunc(t *testing.T) {
-	if shellWrapperFunc() != `__nostromo_cmd() { command nostromo $*; }
-nostromo() { __nostromo_cmd $* && eval "$(__nostromo_cmd completion)"; }` {
+	if shellWrapperFunc() != `__nostromo_cmd() { command nostromo "$@"; }
+nostromo() { __nostromo_cmd "$@" && eval "$(__nostromo_cmd completion)"; }` {
 		t.Errorf("shell wrapper func not as expected")
 	}
 }

--- a/stringutil/stringutil.go
+++ b/stringutil/stringutil.go
@@ -5,21 +5,6 @@ import (
 	"strings"
 )
 
-// SanitizeArgs expands all args by spaces and returns a slice.
-func SanitizeArgs(args []string) []string {
-	sanitizedArgs := []string{}
-	if args == nil {
-		return sanitizedArgs
-	}
-
-	for _, arg := range strings.Split(strings.Join(args, " "), " ") {
-		if len(arg) > 0 {
-			sanitizedArgs = append(sanitizedArgs, strings.TrimSpace(arg))
-		}
-	}
-	return sanitizedArgs
-}
-
 // ContainsCaseInsensitive checks if a string is a substring regardless of case.
 func ContainsCaseInsensitive(s, substr string) bool {
 	return strings.Contains(strings.ToLower(s), strings.ToLower(substr))

--- a/stringutil/stringutil_test.go
+++ b/stringutil/stringutil_test.go
@@ -32,30 +32,6 @@ func TestContainsCaseInsensitive(t *testing.T) {
 	}
 }
 
-func TestSanitizeArgs(t *testing.T) {
-	type args struct {
-		args []string
-	}
-	tests := []struct {
-		name string
-		args args
-		want []string
-	}{
-		{"nil args", args{nil}, []string{}},
-		{"empty args", args{[]string{}}, []string{}},
-		{"single arg", args{[]string{"one"}}, []string{"one"}},
-		{"multi arg", args{[]string{"one", "two", "three"}}, []string{"one", "two", "three"}},
-		{"multi arg strings", args{[]string{"one foo", "two foo bar", "three"}}, []string{"one", "foo", "two", "foo", "bar", "three"}},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := SanitizeArgs(tt.args.args); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("SanitizeArgs() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestReversed(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/task/task.go
+++ b/task/task.go
@@ -388,7 +388,7 @@ func EvalString(args []string) int {
 
 	m := cfg.Manifest()
 
-	language, cmd, err := m.ExecutionString(stringutil.SanitizeArgs(args))
+	language, cmd, err := m.ExecutionString(args)
 	if err != nil {
 		log.Error(err)
 		return -1

--- a/testdata/manifest.json
+++ b/testdata/manifest.json
@@ -50,7 +50,8 @@
                     "language": "",
                     "snippet": ""
                   },
-                  "mode": 0
+                  "mode": 0,
+                  "disabled": false
                 }
               },
               "subs": {
@@ -63,7 +64,8 @@
                 "language": "",
                 "snippet": ""
               },
-              "mode": 0
+              "mode": 0,
+              "disabled": false
             }
           },
           "subs": {
@@ -76,7 +78,8 @@
             "language": "",
             "snippet": ""
           },
-          "mode": 0
+          "mode": 0,
+          "disabled": false
         }
       },
       "subs": {
@@ -89,7 +92,8 @@
         "language": "",
         "snippet": ""
       },
-      "mode": 0
+      "mode": 0,
+      "disabled": false
     },
     "1-one-alias": {
       "keyPath": "1-one-alias",
@@ -129,7 +133,8 @@
                     "language": "",
                     "snippet": ""
                   },
-                  "mode": 0
+                  "mode": 0,
+                  "disabled": false
                 }
               },
               "subs": {
@@ -142,7 +147,8 @@
                 "language": "",
                 "snippet": ""
               },
-              "mode": 0
+              "mode": 0,
+              "disabled": false
             }
           },
           "subs": {
@@ -155,7 +161,8 @@
             "language": "",
             "snippet": ""
           },
-          "mode": 0
+          "mode": 0,
+          "disabled": false
         }
       },
       "subs": {
@@ -168,7 +175,8 @@
         "language": "",
         "snippet": ""
       },
-      "mode": 0
+      "mode": 0,
+      "disabled": false
     }
   }
 }

--- a/testdata/manifest.yaml
+++ b/testdata/manifest.yaml
@@ -45,6 +45,7 @@ commands:
                   language: ""
                   snippet: ""
                 mode: 0
+                disabled: false
             subs:
               0-three-sub:
                 name: 0-three
@@ -53,6 +54,7 @@ commands:
               language: ""
               snippet: ""
             mode: 0
+            disabled: false
         subs:
           0-two-sub:
             name: 0-two
@@ -61,6 +63,7 @@ commands:
           language: ""
           snippet: ""
         mode: 0
+        disabled: false
     subs:
       0-one-sub:
         name: 0-one
@@ -69,6 +72,7 @@ commands:
       language: ""
       snippet: ""
     mode: 0
+    disabled: false
   1-one-alias:
     keypath: 1-one-alias
     name: 1-one
@@ -105,6 +109,7 @@ commands:
                   language: ""
                   snippet: ""
                 mode: 0
+                disabled: false
             subs:
               1-three-sub:
                 name: 1-three
@@ -113,6 +118,7 @@ commands:
               language: ""
               snippet: ""
             mode: 0
+            disabled: false
         subs:
           1-two-sub:
             name: 1-two
@@ -121,6 +127,7 @@ commands:
           language: ""
           snippet: ""
         mode: 0
+        disabled: false
     subs:
       1-one-sub:
         name: 1-one
@@ -129,3 +136,4 @@ commands:
       language: ""
       snippet: ""
     mode: 0
+    disabled: false


### PR DESCRIPTION
Resolves #25 

Add `Disabled` property on `Command` type which prevents a command or any sub-command from being executed.

This feature will allow for dealing with collisions when there are multiple manifests supported.