### PR TITLE
Shell completions rework

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,26 +1,61 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/pokanop/nostromo/task"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 // completionCmd represents the completion command
 var completionCmd = &cobra.Command{
-	Use:   "completion",
-	Short: "Generates shell completion scripts",
-	Long: `To load completion now, run
+	Use:   "completion [bash|zsh|fish|powershell]",
+	Short: "Generate completion script",
+	Long: fmt.Sprintf(`To load completions:
 
-eval "$(nostromo completion)"
+Bash:
 
-To configure your shell to load completions for each session add to your init files.
-Note that "nostromo init" will add this automatically.
+  $ source <(%[1]s completion bash)
 
-# In ~/.bashrc, ~/.bash_profile or ~/.zshrc
-eval "$(nostromo completion)"`,
+  # To load completions for each session, execute once:
+  # Linux:
+  $ %[1]s completion bash > /etc/bash_completion.d/%[1]s
+  # macOS:
+  $ %[1]s completion bash > /usr/local/etc/bash_completion.d/%[1]s
+
+Zsh:
+
+  # If shell completion is not already enabled in your environment,
+  # you will need to enable it.  You can execute the following once:
+
+  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+  # To load completions for each session, execute once:
+  $ %[1]s completion zsh > "${fpath[1]}/_%[1]s"
+
+  # You will need to start a new shell for this setup to take effect.
+
+fish:
+
+  $ %[1]s completion fish | source
+
+  # To load completions for each session, execute once:
+  $ %[1]s completion fish > ~/.config/fish/completions/%[1]s.fish
+
+PowerShell:
+
+  PS> %[1]s completion powershell | Out-String | Invoke-Expression
+
+  # To load completions for every new session, run:
+  PS> %[1]s completion powershell > %[1]s.ps1
+  # and source this file from your PowerShell profile.
+`, rootCmd.Name()),
+	DisableFlagsInUseLine: true,
+	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+	Args:                  cobra.ExactValidArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		os.Exit(task.GenerateCompletions(cmd))
+		os.Exit(task.GenerateCompletions(args[0], cmd.Root(), false))
 	},
 }
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -17,7 +17,7 @@ By default the config file is located at ~/.nostromo/ships/manifest.yaml.
 
 Customize this with the $NOSTROMO_HOME environment variable`,
 	Run: func(cmd *cobra.Command, args []string) {
-		os.Exit(task.InitConfig())
+		os.Exit(task.InitConfig(cmd.Root()))
 	},
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,13 +15,13 @@ var ver *version.Info
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "nostromo",
-	Short: "Nostromo is a tool to manage aliases",
-	Long: `Nostromo is a CLI to manage aliases through simple commands to add and remove
+	Short: "nostromo is a tool to manage aliases",
+	Long: `nostromo is a CLI to manage aliases through simple commands to add and remove
 scoped aliases and substitutions.
 
-Managing aliases can be tedious and difficult to set up. Nostromo makes this process easy
+Managing aliases can be tedious and difficult to set up. nostromo makes this process easy
 and reliable. The tool adds shortcuts to your .bashrc that call into the nostromo binary.
-Nostromo reads and manages all aliases within its own config file.
+nostromo reads and manages all aliases within its own config file.
 This is used to find and execute the actual command intended as well as any
 substitutions to simplify calls.`,
 	SilenceErrors: true,
@@ -47,6 +47,9 @@ func SetVersion(v, c, d string) {
 
 func init() {
 	cobra.OnInitialize(initConfig)
+
+	// Disable default completion command
+	rootCmd.CompletionOptions.DisableDefaultCmd = true
 }
 
 // initConfig reads in config file and ENV variables if set.
@@ -65,5 +68,5 @@ func printUsage(cmd *cobra.Command) {
 }
 
 func printVersion() {
-	log.Regularf("Nostromo: %s\n", ver.Formatted())
+	log.Regularf("nostromo: %s\n", ver.Formatted())
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"github.com/pokanop/nostromo/task"
+	"github.com/spf13/cobra"
+)
+
+// runCmd represents the run command
+var runCmd = &cobra.Command{
+	Use:   "run",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Hidden: true,
+	Run:    func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	rootCmd.AddCommand(runCmd)
+
+	// Add all nostromo commands to the run command
+	runCmd.AddCommand(task.FetchCommands()...)
+}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -7,14 +7,9 @@ import (
 
 // runCmd represents the run command
 var runCmd = &cobra.Command{
-	Use:   "run",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+	Use:    "run",
+	Short:  "Placeholder node for nostromo commands",
+	Long:   `Placeholder node for nostromo commands`,
 	Hidden: true,
 	Run:    func(cmd *cobra.Command, args []string) {},
 }

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -22,7 +22,6 @@ manifests from respective data sources.
 
 Providing a [source] file will sync only that file. Omitting it
 directs nostromo to sync all manifests.`,
-	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		os.Exit(task.Sync(force, args))
 	},

--- a/config/config.go
+++ b/config/config.go
@@ -19,11 +19,12 @@ import (
 
 // Path for standard nostromo config
 const (
-	DefaultBaseDir      = "~/.nostromo"
-	DefaultConfigFile   = "%s.yaml"
-	DefaultManifestsDir = "ships"
-	DefaultBackupsDir   = "cargo"
-	DefaultDownloadsDir = "downloads"
+	DefaultBaseDir        = "~/.nostromo"
+	DefaultConfigFile     = "%s.yaml"
+	DefaultManifestsDir   = "ships"
+	DefaultBackupsDir     = "cargo"
+	DefaultDownloadsDir   = "downloads"
+	DefaultCompletionsDir = "completions"
 )
 
 // URL scheme constants
@@ -121,6 +122,16 @@ func BaseDir() string {
 	}
 
 	return DefaultBaseDir
+}
+
+// WriteCompletion writes a file to the completions folder
+func WriteCompletion(sh, s string) error {
+	if len(sh) == 0 || len(s) == 0 {
+		return fmt.Errorf("attempt to write 0 length file")
+	}
+
+	path := filepath.Join(completionsPath(), fmt.Sprintf("nostromo.%s", sh))
+	return os.WriteFile(path, []byte(s), 0644)
 }
 
 // Spaceport associated with this config
@@ -255,6 +266,11 @@ func manifestsPath() string {
 // backupsPath joins the base directory and the backups directory
 func backupsPath() string {
 	return filepath.Join(pathutil.Abs(BaseDir()), DefaultBackupsDir)
+}
+
+// completionsPath joins the base directory and the manifest directory
+func completionsPath() string {
+	return filepath.Join(pathutil.Abs(BaseDir()), DefaultCompletionsDir)
 }
 
 func coreManifestFile() string {
@@ -468,6 +484,10 @@ func saveManifest(manifest *model.Manifest, backup bool) error {
 // sanitizeFiles is used for moving config files and fixing up any files during upgrades.
 func sanitizeFiles() error {
 	if err := pathutil.EnsurePath(manifestsPath()); err != nil {
+		return err
+	}
+
+	if err := pathutil.EnsurePath(completionsPath()); err != nil {
 		return err
 	}
 

--- a/config/sync.go
+++ b/config/sync.go
@@ -24,6 +24,13 @@ func (c *Config) Sync(force bool, sources []string) error {
 
 	defer syncCleanup()
 
+	// Fallback to all existing manifests if no sources provided
+	if len(sources) == 0 {
+		for _, m := range c.spaceport.Manifests() {
+			sources = append(sources, m.Source)
+		}
+	}
+
 	for _, source := range sources {
 		err := syncDownload(source)
 		if err != nil {

--- a/config/sync.go
+++ b/config/sync.go
@@ -27,6 +27,9 @@ func (c *Config) Sync(force bool, sources []string) error {
 	// Fallback to all existing manifests if no sources provided
 	if len(sources) == 0 {
 		for _, m := range c.spaceport.Manifests() {
+			if m.IsCore() {
+				continue
+			}
 			sources = append(sources, m.Source)
 		}
 	}

--- a/model/command.go
+++ b/model/command.go
@@ -77,7 +77,9 @@ func (c *Command) CobraCommand() *cobra.Command {
 		Use:       c.Alias,
 		Short:     c.Description,
 		Long:      c.Description,
+		Hidden:    true,
 		ValidArgs: c.commandList(),
+		Run:       func(cmd *cobra.Command, args []string) {},
 	}
 	for _, childCmd := range c.Commands {
 		cmd.AddCommand(childCmd.CobraCommand())
@@ -337,7 +339,7 @@ func (c *Command) build(keyPath, command, description string, code *Code, aliasO
 func (c *Command) commandList() []string {
 	var cmds []string
 	for _, cmd := range c.Commands {
-		cmds = append(cmds, cmd.Alias)
+		cmds = append(cmds, fmt.Sprintf("%s\t%s", cmd.Alias, cmd.Description))
 	}
 	sort.Strings(cmds)
 	return cmds
@@ -352,7 +354,7 @@ func (c *Command) checkDisabled() (bool, *Command) {
 		if cmd == nil {
 			break
 		}
-		if cmd.Disabled == true {
+		if cmd.Disabled {
 			return true, cmd
 		}
 		cmd = cmd.parent

--- a/model/spaceport.go
+++ b/model/spaceport.go
@@ -31,6 +31,16 @@ func (s *Spaceport) Manifests() []*Manifest {
 	return manifests
 }
 
+func (s *Spaceport) Commands() []*Command {
+	cmds := []*Command{}
+	for _, m := range s.Manifests() {
+		for _, c := range m.Commands {
+			cmds = append(cmds, c)
+		}
+	}
+	return cmds
+}
+
 func (s *Spaceport) Import(manifests []*Manifest) {
 	s.Sequence = []string{}
 	for _, m := range manifests {

--- a/shell/completion.go
+++ b/shell/completion.go
@@ -45,7 +45,7 @@ func Completion(sh string, cmd *cobra.Command) (string, error) {
 // SpaceportCompletion scripts for all manifests
 func SpaceportCompletion(sh string, s *model.Spaceport) ([]string, error) {
 	var completions []string
-	completions = append(completions, shellWrapperFunc())
+	completions = append(completions, shellWrapperFunc(sh))
 	for _, m := range s.Manifests() {
 		mc, err := ManifestCompletion(sh, m)
 		if err != nil {

--- a/shell/completion.go
+++ b/shell/completion.go
@@ -2,7 +2,7 @@ package shell
 
 import (
 	"bytes"
-	"io/ioutil"
+	"fmt"
 	"strings"
 
 	"github.com/pokanop/nostromo/model"
@@ -15,39 +15,39 @@ type CobraCompleter interface {
 }
 
 // Completion generates shell completion scripts
-func Completion(cmd *cobra.Command) (string, error) {
+func Completion(sh string, cmd *cobra.Command) (string, error) {
 	var buf bytes.Buffer
 	var err error
-	if Which() == Zsh {
+	switch sh {
+	case "bash":
+		err = cmd.GenBashCompletionV2(&buf, true)
+	case "zsh":
+		zshHead := fmt.Sprintf("#compdef %[1]s\ncompdef _%[1]s %[1]s\n", cmd.Name())
+		buf.Write([]byte(zshHead))
 		err = cmd.GenZshCompletion(&buf)
-	} else {
-		err = cmd.GenBashCompletion(&buf)
+	case "fish":
+		err = cmd.GenFishCompletion(&buf, true)
+	case "powershell":
+		err = cmd.GenPowerShellCompletionWithDesc(&buf)
 	}
 	if err != nil {
 		return "", err
 	}
 
-	b, err := ioutil.ReadAll(&buf)
-	if err != nil {
-		return "", err
-	}
-	s := string(b)
-
-	// This is required due to a bug in cobra and zsh support:
-	// https://github.com/spf13/cobra/pull/887
-	if Which() == Zsh {
-		s = strings.Replace(s, "#", "", 1)
+	s := buf.String()
+	if cmd.Name() != "nostromo" {
+		s = strings.ReplaceAll(s, "${words[1]} __complete ${words[2,-1]}", "nostromo __complete run ${words[1]} ${words[2,-1]}")
 	}
 
 	return s, nil
 }
 
 // SpaceportCompletion scripts for all manifests
-func SpaceportCompletion(s *model.Spaceport) ([]string, error) {
+func SpaceportCompletion(sh string, s *model.Spaceport) ([]string, error) {
 	var completions []string
 	completions = append(completions, shellWrapperFunc())
 	for _, m := range s.Manifests() {
-		mc, err := ManifestCompletion(m)
+		mc, err := ManifestCompletion(sh, m)
 		if err != nil {
 			return nil, err
 		}
@@ -57,7 +57,7 @@ func SpaceportCompletion(s *model.Spaceport) ([]string, error) {
 }
 
 // ManifestCompletion scripts for a manifest
-func ManifestCompletion(m *model.Manifest) ([]string, error) {
+func ManifestCompletion(sh string, m *model.Manifest) ([]string, error) {
 	var completions []string
 	completions = append(completions, shellAliasFuncs(m))
 	for _, cmd := range m.Commands {
@@ -66,7 +66,7 @@ func ManifestCompletion(m *model.Manifest) ([]string, error) {
 		if cmd.AliasOnly || len(cmd.Commands) == 0 {
 			continue
 		}
-		s, err := CommandCompletion(cmd)
+		s, err := CommandCompletion(sh, cmd)
 		if err != nil {
 			return nil, err
 		}
@@ -76,6 +76,6 @@ func ManifestCompletion(m *model.Manifest) ([]string, error) {
 }
 
 // CommandCompletion script for a command
-func CommandCompletion(cmd *model.Command) (string, error) {
-	return Completion(cmd.CobraCommand())
+func CommandCompletion(sh string, cmd *model.Command) (string, error) {
+	return Completion(sh, cmd.CobraCommand())
 }

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -2,20 +2,18 @@ package shell
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/pokanop/nostromo/log"
 	"github.com/pokanop/nostromo/model"
 )
 
-// Shell type
-type Shell int
-
 // Supported shells
 const (
-	Bash Shell = iota
-	Zsh
+	Bash       = "bash"
+	Zsh        = "zsh"
+	Fish       = "fish"
+	Powershell = "powershell"
 )
 
 var validLanguages = []string{"sh", "ruby", "python", "perl", "js"}
@@ -23,7 +21,6 @@ var validLanguages = []string{"sh", "ruby", "python", "perl", "js"}
 var (
 	initFiles = loadStartupFiles()
 	prefFiles = preferredStartupFiles(initFiles)
-	prefFile  = currentStartupFile(initFiles)
 )
 
 // EvalString returns the command as a string to evaluate or an error.
@@ -68,20 +65,16 @@ func Commit(manifest *model.Manifest) error {
 }
 
 // InitFileLines returns the shell initialization file lines
-func InitFileLines() (string, error) {
-	if prefFile == nil {
-		return "", fmt.Errorf("could not find current init file")
+func InitFileLines() string {
+	var s string
+	for _, prefFile := range prefFiles {
+		s += fmt.Sprintf("|%s|", prefFile.name())
+		c, err := prefFile.contentBlock()
+		if err == nil {
+			s += c
+		}
 	}
-	return prefFile.contentBlock()
-}
-
-// Which shell is currently running
-func Which() Shell {
-	sh := os.Getenv("SHELL")
-	if strings.Contains(sh, "zsh") {
-		return Zsh
-	}
-	return Bash
+	return s
 }
 
 // SupportedLanguages that can be executed
@@ -116,13 +109,9 @@ func buildEvalCmd(cmd, language string) string {
 	}
 }
 
-func shellWrapperFunc() string {
+func shellWrapperFunc(sh string) string {
 	// Sources completion scripts after each command in case something changes
-	sh := "bash"
-	if Which() == Zsh {
-		sh = "zsh"
-	}
-	return fmt.Sprintf("__nostromo_cmd() { command ./nostromo \"$@\"; }\nnostromo() { __nostromo_cmd \"$@\" && eval \"$(__nostromo_cmd completion %s)\"; }", sh)
+	return fmt.Sprintf("__nostromo_cmd() { command nostromo \"$@\"; }\nnostromo() { __nostromo_cmd \"$@\" && eval \"$(__nostromo_cmd completion %s)\"; }", sh)
 }
 
 func shellAliasFuncs(m *model.Manifest) string {

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -118,8 +118,11 @@ func buildEvalCmd(cmd, language string) string {
 
 func shellWrapperFunc() string {
 	// Sources completion scripts after each command in case something changes
-	return `__nostromo_cmd() { command nostromo "$@"; }
-nostromo() { __nostromo_cmd "$@" && eval "$(__nostromo_cmd completion)"; }`
+	sh := "bash"
+	if Which() == Zsh {
+		sh = "zsh"
+	}
+	return fmt.Sprintf("__nostromo_cmd() { command ./nostromo \"$@\"; }\nnostromo() { __nostromo_cmd \"$@\" && eval \"$(__nostromo_cmd completion %s)\"; }", sh)
 }
 
 func shellAliasFuncs(m *model.Manifest) string {
@@ -130,7 +133,7 @@ func shellAliasFuncs(m *model.Manifest) string {
 			alias = fmt.Sprintf("alias %s='%s'", c.Alias, c.Name)
 		} else {
 			// This will generate a shell command provided to the completion script
-			// generation. When users run a command, it actually runs evaluates
+			// generation. When users run a command, it actually runs `eval` on
 			// the result of `nostromo eval` with arguments resolved.
 			cmd := fmt.Sprintf("__nostromo_cmd eval %s \"$@\"", c.Alias)
 			alias = strings.TrimSpace(fmt.Sprintf("%s() { eval $(%s); }", c.Alias, cmd))

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -80,8 +80,8 @@ func TestEvalString(t *testing.T) {
 }
 
 func TestShellWrapperFunc(t *testing.T) {
-	if shellWrapperFunc() != `__nostromo_cmd() { command nostromo "$@"; }
-nostromo() { __nostromo_cmd "$@" && eval "$(__nostromo_cmd completion)"; }` {
+	if shellWrapperFunc("zsh") != `__nostromo_cmd() { command nostromo "$@"; }
+nostromo() { __nostromo_cmd "$@" && eval "$(__nostromo_cmd completion zsh)"; }` {
 		t.Errorf("shell wrapper func not as expected")
 	}
 }

--- a/shell/startupfile.go
+++ b/shell/startupfile.go
@@ -14,9 +14,10 @@ import (
 )
 
 const (
-	beginBlockComment = "# nostromo [section begin]"
-	endBlockComment   = "# nostromo [section end]"
-	sourceCompletion  = "eval \"$(nostromo completion)\""
+	beginBlockComment    = "# nostromo [section begin]"
+	endBlockComment      = "# nostromo [section end]"
+	bashSourceCompletion = "source <(./nostromo completion bash)"
+	zshSourceCompletion  = "autoload -U compinit; compinit\nsource <(./nostromo completion zsh)"
 )
 
 var (
@@ -263,5 +264,9 @@ func (s *startupFile) contentIndexes() (int, int) {
 }
 
 func (s *startupFile) makeNostromoBlock() string {
+	sourceCompletion := bashSourceCompletion
+	if Which() == Zsh {
+		sourceCompletion = zshSourceCompletion
+	}
 	return fmt.Sprintf("\n%s\n%s\n%s\n", beginBlockComment, sourceCompletion, endBlockComment)
 }

--- a/shell/startupfile_test.go
+++ b/shell/startupfile_test.go
@@ -34,10 +34,10 @@ func TestStartupFile(t *testing.T) {
 		{"malformed block 2", ".zshrc", "export PATH=/usr/local/bin\nexport FOO=bar\n\n# nostromo [section begin]\neval \"$(nostromo completion)\"\nalias foo='nostromo eval foo \"$*\"'\nalias bar='nostromo eval bar \"$*\"'# nostromo [section begin]", makeManifest("foo", "baz"), true, false, true, true, ""},
 		{"empty profile", ".profile", "", man(), false, true, false, false, ""},
 		{"empty bash_profile", ".bash_profile", "", man(), false, true, false, false, ""},
-		{"empty bashrc", ".bashrc", "", man(), true, true, false, false, "\n# nostromo [section begin]\neval \"$(nostromo completion)\"\n# nostromo [section end]\n"},
-		{"empty zshrc", ".zshrc", "", man(), true, true, false, false, "\n# nostromo [section begin]\neval \"$(nostromo completion)\"\n# nostromo [section end]\n"},
+		{"empty bashrc", ".bashrc", "", man(), true, true, false, false, "\n# nostromo [section begin]\nsource <(nostromo completion bash)\n# nostromo [section end]\n"},
+		{"empty zshrc", ".zshrc", "", man(), true, true, false, false, "\n# nostromo [section begin]\nautoload -U compinit; compinit\nsource <(nostromo completion zsh)\n# nostromo [section end]\n"},
 		{"existing non-preferred no commands", ".profile", "export PATH=/usr/local/bin\nexport FOO=bar", man(), false, true, false, false, "export PATH=/usr/local/bin\nexport FOO=bar"},
-		{"existing preferred no commands", ".zshrc", "export PATH=/usr/local/bin\nexport FOO=bar", man(), true, true, false, false, "export PATH=/usr/local/bin\nexport FOO=bar\n# nostromo [section begin]\neval \"$(nostromo completion)\"\n# nostromo [section end]\n"},
+		{"existing preferred no commands", ".zshrc", "export PATH=/usr/local/bin\nexport FOO=bar", man(), true, true, false, false, "export PATH=/usr/local/bin\nexport FOO=bar\n# nostromo [section begin]\nautoload -U compinit; compinit\nsource <(nostromo completion zsh)\n# nostromo [section end]\n"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -110,31 +110,6 @@ func TestPreferredStartupFiles(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			if got := preferredStartupFiles(test.files); !reflect.DeepEqual(got, test.want) {
 				t.Errorf("preferredStartupFiles() = %v, want %v", got, test.want)
-			}
-		})
-	}
-}
-
-func TestCurrentStartupFile(t *testing.T) {
-	type args struct {
-		env   string
-		files []*startupFile
-	}
-	tests := []struct {
-		name string
-		args args
-		want *startupFile
-	}{
-		{"nil files", args{"", nil}, nil},
-		{"not startup file", args{"zsh", []*startupFile{makeStartupFileCommon(".foo", "", true)}}, nil},
-		{"zsh", args{"zsh", []*startupFile{makeStartupFileCommon(".zshrc", "", true)}}, makeStartupFileCommon(".zshrc", "", true)},
-		{"bash", args{"bash", []*startupFile{makeStartupFileCommon(".bashrc", "", true)}}, makeStartupFileCommon(".bashrc", "", true)},
-	}
-	for _, tt := range tests {
-		os.Setenv("SHELL", tt.args.env)
-		t.Run(tt.name, func(t *testing.T) {
-			if got := currentStartupFile(tt.args.files); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("currentStartupFile() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/task/task.go
+++ b/task/task.go
@@ -132,11 +132,7 @@ func ShowConfig(asJSON bool, asYAML bool, asTree bool) int {
 				log.Regular()
 			}
 
-			lines, err := shell.InitFileLines()
-			if err != nil {
-				return -1
-			}
-
+			lines := shell.InitFileLines()
 			if m.IsCore() {
 				log.Bold("[profile]")
 				if len(lines) > 0 {

--- a/task/task.go
+++ b/task/task.go
@@ -16,7 +16,7 @@ import (
 )
 
 // InitConfig of nostromo config file if not already initialized
-func InitConfig() int {
+func InitConfig(cmd *cobra.Command) int {
 	// Attempt to load existing config
 	cfg, err := config.LoadConfig()
 	if err != nil {
@@ -36,6 +36,12 @@ func InitConfig() int {
 		log.Error(err)
 		return -1
 	}
+
+	// Generate completion files
+	GenerateCompletions("bash", cmd, true)
+	GenerateCompletions("zsh", cmd, true)
+	GenerateCompletions("fish", cmd, true)
+	GenerateCompletions("powershell", cmd, true)
 
 	return 0
 }
@@ -178,14 +184,33 @@ func GetConfig(key string) int {
 	return 0
 }
 
+// FetchCommands builds the nostromo command tree and returns the top level
+// commands for execution
+func FetchCommands() []*cobra.Command {
+	cmds := []*cobra.Command{}
+
+	cfg := checkConfigQuiet()
+	if cfg == nil {
+		return cmds
+	}
+
+	for _, cmd := range cfg.Spaceport().Commands() {
+		cmds = append(cmds, cmd.CobraCommand())
+	}
+
+	return cmds
+}
+
 // GenerateCompletions for all manifest commands and nostromo itself.
-func GenerateCompletions(cmd *cobra.Command) int {
+func GenerateCompletions(sh string, cmd *cobra.Command, writeFile bool) int {
 	// Generate completions for nostromo
-	s, err := shell.Completion(cmd)
+	s, err := shell.Completion(sh, cmd)
 	if err != nil {
 		return -1
 	}
-	log.Print(s)
+	if !writeFile {
+		log.Print(s)
+	}
 
 	cfg := checkConfigQuiet()
 	if cfg == nil {
@@ -193,13 +218,23 @@ func GenerateCompletions(cmd *cobra.Command) int {
 	}
 
 	// Generate completions for manifest commands
-	completions, err := shell.SpaceportCompletion(cfg.Spaceport())
+	completions, err := shell.SpaceportCompletion(sh, cfg.Spaceport())
 	if err != nil {
 		return 0
 	}
 
 	for _, completion := range completions {
-		log.Print(completion)
+		if !writeFile {
+			log.Print(completion)
+		}
+		s += "\n" + completion
+	}
+
+	if writeFile {
+		err = config.WriteCompletion(sh, s)
+		if err != nil {
+			log.Warningf("unable to write completion file for %s", sh)
+		}
 	}
 
 	return 0


### PR DESCRIPTION
Resolves #46

Shell completions were broken after upgrading to the latest cobra package. They redesigned how they handle zsh autocompletions by routing it through the command itself with a hidden `__complete` command to generate the completions.

This broke how we used `nostromo eval` to run the commands and none of the tab completions were working. The fix was to add the nostromo generated command tree into the main cobra root command under a hidden `run` command. This way the completion scripts can navigate the tree for user generated commands as well.

Needed to hack the completion script to replace the standard root commands with a `nostromo run` prefix so cobra could generate the autocompletion.

Fixes the empty sync command to update all existing manifests:
```sh
nostromo sync
```

Tested in zsh. Still need to go back and test bash and make it work for fish and powershell.