### PR TITLE
Add uuidgen command to refresh manifest identifier

### DIFF
--- a/cmd/uuidgen.go
+++ b/cmd/uuidgen.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/pokanop/nostromo/task"
+	"github.com/spf13/cobra"
+)
+
+// uuidgenCmd represents the uuidgen command
+var uuidgenCmd = &cobra.Command{
+	Use:   "uuidgen [name]",
+	Short: "Generate a new unique id for a manifest",
+	Long: `Generate a new unique id for a manifest.
+
+nostromo uses a uuid to determine if a manifest is unique or not.
+When using sync to get new manifests, nostromo will only apply the
+changes if it detects a different identifier.
+
+This command allows regenerating the uuid to allow for publishing
+and pulling updated manifests. Note that using standard nostromo
+commands automatically updates the identifier. This command can be
+used if manual updates were made to a manifest.
+
+Omitting the name of the manifest will apply to the core manifest.`,
+	Args: cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		var name string
+		if len(args) > 0 {
+			name = args[0]
+		}
+		os.Exit(task.RegenerateID(name))
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(uuidgenCmd)
+}

--- a/config/config.go
+++ b/config/config.go
@@ -168,11 +168,11 @@ func Parse(path string) (*model.Manifest, error) {
 
 // SaveSpaceport to nostromo config folder
 func SaveSpaceport(s *model.Spaceport) error {
-	log.Debug("saving spaceport")
-
 	if s == nil {
 		return fmt.Errorf("spaceport is nil")
 	}
+
+	log.Debug("saving spaceport")
 
 	b, err := yaml.Marshal(s)
 	if err != nil {
@@ -189,11 +189,11 @@ func SaveSpaceport(s *model.Spaceport) error {
 
 // SaveManifest to nostromo config folder and backup optionally
 func SaveManifest(manifest *model.Manifest, backup bool) error {
-	log.Debugf("saving manifest %s\n", manifest.Name)
-
 	if manifest == nil {
 		return fmt.Errorf("manifest is nil")
 	}
+
+	log.Debugf("saving manifest %s\n", manifest.Name)
 
 	if len(manifest.Path) == 0 {
 		return fmt.Errorf("invalid path to save")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -32,7 +32,7 @@ func TestLoadConfig(t *testing.T) {
 
 			// Create temporary spaceport file
 			s := model.NewSpaceport(tt.manifests)
-			saveSpaceport(s)
+			SaveSpaceport(s)
 
 			// Copy manifest to target locations
 			src, _ := os.Open("../testdata/manifest.yaml")
@@ -121,7 +121,7 @@ func TestParse(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			m, err := parse(test.path)
+			m, err := Parse(test.path)
 			if test.expErr && err == nil {
 				t.Errorf("expected error but got none")
 			} else if !test.expErr {
@@ -157,7 +157,7 @@ func TestSave(t *testing.T) {
 			if test.config != nil {
 				m = test.config.spaceport.CoreManifest()
 			}
-			err := saveManifest(m, false)
+			err := SaveManifest(m, false)
 			if test.expErr && err == nil {
 				t.Errorf("expected error but got none")
 			} else if !test.expErr && err != nil {
@@ -184,7 +184,7 @@ func TestDelete(t *testing.T) {
 				if test.config != nil {
 					m = test.config.spaceport.CoreManifest()
 				}
-				err := saveManifest(m, false)
+				err := SaveManifest(m, false)
 				if err != nil {
 					t.Errorf("unable to save temporary manifest: %s", err)
 				}
@@ -373,9 +373,9 @@ func TestBackup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			os.Setenv("NOSTROMO_HOME", tt.baseDir)
 
-			m, err := parse("../testdata/manifest.yaml")
+			m, err := Parse("../testdata/manifest.yaml")
 			if err != nil {
-				t.Errorf("failed to parse manifest: %s", err)
+				t.Errorf("failed to Parse manifest: %s", err)
 			}
 
 			manifests := []*model.Manifest{m}

--- a/task/task.go
+++ b/task/task.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pokanop/nostromo/prompt"
 	"github.com/pokanop/nostromo/shell"
 	"github.com/pokanop/nostromo/stringutil"
+	"github.com/pokanop/nostromo/version"
 	"github.com/shivamMg/ppds/tree"
 	"github.com/spf13/cobra"
 )
@@ -584,6 +585,31 @@ func Detach(name string, keyPaths []string, targetKeyPath, description string, k
 		return -1
 	}
 	err = config.SaveSpaceport(s)
+	if err != nil {
+		log.Error(err)
+		return -1
+	}
+
+	return 0
+}
+
+func RegenerateID(name string) int {
+	cfg := checkConfig()
+	var m *model.Manifest
+	if len(name) > 0 {
+		m = cfg.Spaceport().FindManifest(name)
+		if m == nil {
+			log.Errorf("no manifest named %s exists\n", name)
+			return -1
+		}
+	} else {
+		m = cfg.Spaceport().CoreManifest()
+	}
+
+	v := version.NewInfo(m.Version.SemVer, m.Version.GitCommit, m.Version.BuildDate)
+	m.Version.Update(v)
+
+	err := config.SaveManifest(m, m.IsCore())
 	if err != nil {
 		log.Error(err)
 		return -1


### PR DESCRIPTION
New command for manually edited manifests to update the uuid. This allows for sync features to update unique changes.
```sh
# Updates the core manifest
nostromo uuidgen

# Update a different manifest
nostromo uuidgen [name]
```