### PR TITLE
Add move and rename commands, clean up

### DIFF
--- a/cmd/move.go
+++ b/cmd/move.go
@@ -1,33 +1,19 @@
 package cmd
 
 import (
-	"os"
-
-	"github.com/pokanop/nostromo/task"
 	"github.com/spf13/cobra"
 )
 
 // moveCmd represents the move command
 var moveCmd = &cobra.Command{
-	Use:   "move [source] [dest] [options]",
-	Short: "Move a command from one key path to another",
-	Long: `Move a command from one key path to another.
-
-Manipulate the core nostromo manifest by moving command nodes.
-Using move, take a source key path and shift it to the destination
-key path with all subcommands in tow.
-
-If the destination key path does not exist, it will be created
-and the node will be moved there. Optionally provide a description
-with -d to the destination.`,
-	Args: cobra.ExactArgs(2),
+	Use:   "move",
+	Short: "Move a command in nostromo manifest",
+	Long:  "Move a command in nostromo manifest",
 	Run: func(cmd *cobra.Command, args []string) {
-		os.Exit(task.MoveCommand(args[0], args[1], description))
+		printUsage(cmd)
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(moveCmd)
-
-	moveCmd.Flags().StringVarP(&description, "description", "d", "", "Description of the command to add")
 }

--- a/cmd/move.go
+++ b/cmd/move.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/pokanop/nostromo/task"
+	"github.com/spf13/cobra"
+)
+
+// moveCmd represents the move command
+var moveCmd = &cobra.Command{
+	Use:   "move [source] [dest] [options]",
+	Short: "Move a command from one key path to another",
+	Long: `Move a command from one key path to another.
+
+Manipulate the core nostromo manifest by moving command nodes.
+Using move, take a source key path and shift it to the destination
+key path with all subcommands in tow.
+
+If the destination key path does not exist, it will be created
+and the node will be moved there. Optionally provide a description
+with -d to the destination.`,
+	Args: cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		os.Exit(task.MoveCommand(args[0], args[1], description))
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(moveCmd)
+
+	moveCmd.Flags().StringVarP(&description, "description", "d", "", "Description of the command to add")
+}

--- a/cmd/movecmd.go
+++ b/cmd/movecmd.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/pokanop/nostromo/task"
+	"github.com/spf13/cobra"
+)
+
+var rename string
+
+// movecmdCmd represents the movecmd command
+var movecmdCmd = &cobra.Command{
+	Use:   "cmd [src.key.path] [dest.key.path] [options]",
+	Short: "Move a command in nostromo manifest",
+	Long: `Move a command in nostromo manifest for a given key path.
+A key path is a '.' delimited string, e.g., "key.path" which represents
+the alias which can be run as "key path" for the actual command provided.
+
+Manipulate the core nostromo manifest by moving command nodes.
+Using move, take a source key path and shift it to the destination
+key path with all subcommands in tow.
+
+If the destination key path does not exist, it will be created
+and the node will be moved there. Optionally provide a description
+with -d to the destination.
+
+To move a node to the root, do not provide a destination key path.
+
+To rename a node only, pass the -r flag with a name to use.`,
+	Args: cobra.RangeArgs(1, 2),
+	Run: func(cmd *cobra.Command, args []string) {
+		var dest string
+		if len(args) > 1 {
+			dest = args[1]
+		}
+		if len(rename) == 0 {
+			os.Exit(task.MoveCommand(args[0], dest, description))
+		} else {
+			os.Exit(task.RenameCommand(args[0], rename, description))
+		}
+	},
+}
+
+func init() {
+	moveCmd.AddCommand(movecmdCmd)
+
+	movecmdCmd.Flags().StringVarP(&description, "description", "d", "", "Description of the destination to move command")
+	movecmdCmd.Flags().StringVarP(&rename, "rename", "r", "", "Rename command instead of moving")
+}

--- a/examples/docker.yaml
+++ b/examples/docker.yaml
@@ -1,0 +1,79 @@
+name: docker
+source: file:///Users/saheljalal/.nostromo/ships/docker.yaml
+path: /Users/saheljalal/.nostromo/ships/docker.yaml
+version:
+  uuid: e1eea91e-6a6f-4838-b12b-7063732e4a56
+  semver: 0.9.2
+  gitcommit: 8a2350c0d5700cf2066977089f133af7daf7df60
+  builddate: "2022-02-02T23:29:30Z"
+config:
+  verbose: false
+  aliasesonly: false
+  mode: 0
+  backupcount: 10
+commands:
+  docker:
+    keypath: dock
+    name: docker
+    alias: dock
+    aliasonly: false
+    description: Alias for docker
+    commands:
+      clean:
+        keypath: dock.clean
+        name: ps -a -q |xargs docker rm
+        alias: clean
+        aliasonly: false
+        description: Remove Docker containers using docker rm
+        commands: {}
+        subs: {}
+        code:
+          language: ""
+          snippet: ""
+        mode: 0
+        disabled: false
+      rmi:
+        keypath: dock.rmi
+        name: rmi $(docker images -q)
+        alias: rmi
+        aliasonly: false
+        description: Remove Docker images using docker rmi
+        commands: {}
+        subs: {}
+        code:
+          language: ""
+          snippet: ""
+        mode: 0
+        disabled: false
+      stop:
+        keypath: dock.stop
+        name: ps -q |xargs docker stop
+        alias: stop
+        aliasonly: false
+        description: Stop running Docker containers
+        commands: {}
+        subs: {}
+        code:
+          language: ""
+          snippet: ""
+        mode: 0
+        disabled: false
+      vol:
+        keypath: dock.vol
+        name: volume rm $(docker volume ls -qf dangling=true)
+        alias: vol
+        aliasonly: false
+        description: Remove dangling Docker volumes
+        commands: {}
+        subs: {}
+        code:
+          language: ""
+          snippet: ""
+        mode: 0
+        disabled: false
+    subs: {}
+    code:
+      language: ""
+      snippet: ""
+    mode: 0
+    disabled: false

--- a/examples/docker.yaml
+++ b/examples/docker.yaml
@@ -1,6 +1,6 @@
 name: docker
-source: file:///Users/saheljalal/.nostromo/ships/docker.yaml
-path: /Users/saheljalal/.nostromo/ships/docker.yaml
+source: https://github.com/pokanop/nostromo/blob/main/examples/docker.yaml
+path: /Users/gopher/.nostromo/ships/docker.yaml
 version:
   uuid: e1eea91e-6a6f-4838-b12b-7063732e4a56
   semver: 0.9.2

--- a/examples/edit.yaml
+++ b/examples/edit.yaml
@@ -1,0 +1,144 @@
+name: edit
+source: file:///Users/saheljalal/.nostromo/ships/edit.yaml
+path: /Users/saheljalal/.nostromo/ships/edit.yaml
+version:
+  uuid: 08f24962-402a-4323-a843-71c594b1c816
+  semver: 0.9.2
+  gitcommit: 8a2350c0d5700cf2066977089f133af7daf7df60
+  builddate: "2022-02-02T23:29:30Z"
+config:
+  verbose: false
+  aliasesonly: false
+  mode: 0
+  backupcount: 10
+commands:
+  "":
+    keypath: edit
+    name: ""
+    alias: edit
+    aliasonly: false
+    description: ""
+    commands:
+      bash:
+        keypath: edit.bash
+        name: vim ~/.bashrc
+        alias: bash
+        aliasonly: false
+        description: Edit bashrc config file using vim
+        commands: {}
+        subs: {}
+        code:
+          language: ""
+          snippet: ""
+        mode: 0
+        disabled: false
+      bash_profile:
+        keypath: edit.bash_profile
+        name: vim ~/.bash_profile
+        alias: bash_profile
+        aliasonly: false
+        description: Edit bash_profile config file using vim
+        commands: {}
+        subs: {}
+        code:
+          language: ""
+          snippet: ""
+        mode: 0
+        disabled: false
+      nostromo:
+        keypath: edit.nostromo
+        name: vim ~/.nostromo/manifest.yaml
+        alias: nostromo
+        aliasonly: false
+        description: Edit nostromo manifest file using vim
+        commands: {}
+        subs: {}
+        code:
+          language: ""
+          snippet: ""
+        mode: 0
+        disabled: false
+      p10k:
+        keypath: edit.p10k
+        name: vim ~/.p10k.zsh
+        alias: p10k
+        aliasonly: false
+        description: Edit p10k config file in vim
+        commands: {}
+        subs: {}
+        code:
+          language: ""
+          snippet: ""
+        mode: 0
+        disabled: false
+      profile:
+        keypath: edit.profile
+        name: vim ~/.profile
+        alias: profile
+        aliasonly: false
+        description: Edit profile config file using vim
+        commands: {}
+        subs: {}
+        code:
+          language: ""
+          snippet: ""
+        mode: 0
+        disabled: false
+      ssh:
+        keypath: edit.ssh
+        name: vim ~/.ssh/config
+        alias: ssh
+        aliasonly: false
+        description: Edit ssh config file in vim
+        commands:
+          hosts:
+            keypath: edit.ssh.hosts
+            name: vim ~/.ssh/hosts
+            alias: hosts
+            aliasonly: false
+            description: Edit ssh hosts file in vim
+            commands: {}
+            subs: {}
+            code:
+              language: ""
+              snippet: ""
+            mode: 2
+            disabled: false
+        subs: {}
+        code:
+          language: ""
+          snippet: ""
+        mode: 0
+        disabled: false
+      terminalizer:
+        keypath: edit.terminalizer
+        name: vim ~/.terminalizer/config.yml
+        alias: terminalizer
+        aliasonly: false
+        description: Edit terminalizer config file
+        commands: {}
+        subs: {}
+        code:
+          language: ""
+          snippet: ""
+        mode: 0
+        disabled: false
+      zsh:
+        keypath: edit.zsh
+        name: vim ~/.zshrc
+        alias: zsh
+        aliasonly: false
+        description: Edit zsh config file using vim
+        commands: {}
+        subs: {}
+        code:
+          language: ""
+          snippet: ""
+        mode: 0
+        disabled: false
+    subs: {}
+    code:
+      language: ""
+      snippet: ""
+    mode: 0
+    disabled: false

--- a/examples/edit.yaml
+++ b/examples/edit.yaml
@@ -1,6 +1,6 @@
 name: edit
-source: file:///Users/saheljalal/.nostromo/ships/edit.yaml
-path: /Users/saheljalal/.nostromo/ships/edit.yaml
+source: https://github.com/pokanop/nostromo/blob/main/examples/edit.yaml
+path: /Users/gopher/.nostromo/ships/edit.yaml
 version:
   uuid: 08f24962-402a-4323-a843-71c594b1c816
   semver: 0.9.2

--- a/examples/manifest.yaml
+++ b/examples/manifest.yaml
@@ -1,6 +1,6 @@
 name: manifest
-source: file:///Users/saheljalal/.nostromo/ships/manifest.yaml
-path: /Users/saheljalal/.nostromo/ships/manifest.yaml
+source: https://github.com/pokanop/nostromo/blob/main/examples/manifest.yaml
+path: /Users/gopher/.nostromo/ships/manifest.yaml
 version:
   uuid: 615ce229-14f6-41b6-bf2b-daf792a7ed71
   semver: 0.9.2

--- a/examples/manifest.yaml
+++ b/examples/manifest.yaml
@@ -1,8 +1,11 @@
+name: manifest
+source: file:///Users/saheljalal/.nostromo/ships/manifest.yaml
+path: /Users/saheljalal/.nostromo/ships/manifest.yaml
 version:
-  uuid: ed18610b-3b89-4408-bbed-e9a07753f775
-  semver: 0.8.0
-  gitcommit: 8185870fd83f5f165ce76fb0a70e5cd7aff1a8cd
-  builddate: '2022-01-22T08:33:26Z'
+  uuid: 615ce229-14f6-41b6-bf2b-daf792a7ed71
+  semver: 0.9.2
+  gitcommit: 8a2350c0d5700cf2066977089f133af7daf7df60
+  builddate: "2022-02-02T23:29:30Z"
 config:
   verbose: false
   aliasesonly: false
@@ -18,15 +21,62 @@ commands:
     commands: {}
     subs: {}
     code:
-      language: ''
-      snippet: ''
+      language: ""
+      snippet: ""
     mode: 0
+    disabled: false
+  cat:
+    keypath: cat
+    name: bat
+    alias: cat
+    aliasonly: false
+    description: Use bat as a better cat tool
+    commands: {}
+    subs: {}
+    code:
+      language: ""
+      snippet: ""
+    mode: 0
+    disabled: false
+  check:
+    keypath: check
+    name: which $1 > /dev/null 2>&1 && echo $1 exists || (echo $1 not found && exit
+      1)
+    alias: check
+    aliasonly: false
+    description: Check if a command or tool is installed
+    commands: {}
+    subs: {}
+    code:
+      language: ""
+      snippet: ""
+    mode: 0
+    disabled: false
+  code:
+    keypath: code
+    name: command code
+    alias: code
+    aliasonly: false
+    description: Shortcut with substitutions for VSCode
+    commands: {}
+    subs:
+      nostromo:
+        name: ~/.nostromo/manifest.yaml
+        alias: nostromo
+      zsh:
+        name: ~/.zshrc
+        alias: zsh
+    code:
+      language: ""
+      snippet: ""
+    mode: 0
+    disabled: false
   copy:
     keypath: copy
-    name: ''
+    name: ""
     alias: copy
     aliasonly: false
-    description: ''
+    description: ""
     commands:
       ssh:
         keypath: copy.ssh
@@ -37,80 +87,87 @@ commands:
         commands: {}
         subs: {}
         code:
-          language: ''
-          snippet: ''
+          language: ""
+          snippet: ""
         mode: 0
+        disabled: false
     subs: {}
     code:
-      language: ''
-      snippet: ''
+      language: ""
+      snippet: ""
     mode: 0
+    disabled: false
   dock:
     keypath: dock
-    name: ''
+    name: docker
     alias: dock
     aliasonly: false
-    description: ''
+    description: Alias for docker
     commands:
       clean:
         keypath: dock.clean
-        name: docker ps -a -q |xargs docker rm
+        name: ps -a -q |xargs docker rm
         alias: clean
         aliasonly: false
         description: Remove Docker containers using docker rm
         commands: {}
         subs: {}
         code:
-          language: ''
-          snippet: ''
+          language: ""
+          snippet: ""
         mode: 0
+        disabled: false
       rmi:
         keypath: dock.rmi
-        name: docker rmi $(docker images -q)
+        name: rmi $(docker images -q)
         alias: rmi
         aliasonly: false
         description: Remove Docker images using docker rmi
         commands: {}
         subs: {}
         code:
-          language: ''
-          snippet: ''
+          language: ""
+          snippet: ""
         mode: 0
+        disabled: false
       stop:
         keypath: dock.stop
-        name: docker ps -q |xargs docker stop
+        name: ps -q |xargs docker stop
         alias: stop
         aliasonly: false
         description: Stop running Docker containers
         commands: {}
         subs: {}
         code:
-          language: ''
-          snippet: ''
+          language: ""
+          snippet: ""
         mode: 0
+        disabled: false
       vol:
         keypath: dock.vol
-        name: docker volume rm $(docker volume ls -qf dangling=true)
+        name: volume rm $(docker volume ls -qf dangling=true)
         alias: vol
         aliasonly: false
         description: Remove dangling Docker volumes
         commands: {}
         subs: {}
         code:
-          language: ''
-          snippet: ''
+          language: ""
+          snippet: ""
         mode: 0
+        disabled: false
     subs: {}
     code:
-      language: ''
-      snippet: ''
+      language: ""
+      snippet: ""
     mode: 0
+    disabled: false
   edit:
     keypath: edit
-    name: ''
+    name: ""
     alias: edit
     aliasonly: false
-    description: ''
+    description: ""
     commands:
       bash:
         keypath: edit.bash
@@ -121,9 +178,10 @@ commands:
         commands: {}
         subs: {}
         code:
-          language: ''
-          snippet: ''
+          language: ""
+          snippet: ""
         mode: 0
+        disabled: false
       bash_profile:
         keypath: edit.bash_profile
         name: vim ~/.bash_profile
@@ -133,21 +191,23 @@ commands:
         commands: {}
         subs: {}
         code:
-          language: ''
-          snippet: ''
+          language: ""
+          snippet: ""
         mode: 0
+        disabled: false
       nostromo:
         keypath: edit.nostromo
-        name: vim ~/.nostromo/ships/manifest.yaml
+        name: vim ~/.nostromo/manifest.yaml
         alias: nostromo
         aliasonly: false
         description: Edit nostromo manifest file using vim
         commands: {}
         subs: {}
         code:
-          language: ''
-          snippet: ''
+          language: ""
+          snippet: ""
         mode: 0
+        disabled: false
       p10k:
         keypath: edit.p10k
         name: vim ~/.p10k.zsh
@@ -157,9 +217,10 @@ commands:
         commands: {}
         subs: {}
         code:
-          language: ''
-          snippet: ''
+          language: ""
+          snippet: ""
         mode: 0
+        disabled: false
       profile:
         keypath: edit.profile
         name: vim ~/.profile
@@ -169,9 +230,10 @@ commands:
         commands: {}
         subs: {}
         code:
-          language: ''
-          snippet: ''
+          language: ""
+          snippet: ""
         mode: 0
+        disabled: false
       ssh:
         keypath: edit.ssh
         name: vim ~/.ssh/config
@@ -188,14 +250,29 @@ commands:
             commands: {}
             subs: {}
             code:
-              language: ''
-              snippet: ''
+              language: ""
+              snippet: ""
             mode: 2
+            disabled: false
         subs: {}
         code:
-          language: ''
-          snippet: ''
+          language: ""
+          snippet: ""
         mode: 0
+        disabled: false
+      terminalizer:
+        keypath: edit.terminalizer
+        name: vim ~/.terminalizer/config.yml
+        alias: terminalizer
+        aliasonly: false
+        description: Edit terminalizer config file
+        commands: {}
+        subs: {}
+        code:
+          language: ""
+          snippet: ""
+        mode: 0
+        disabled: false
       zsh:
         keypath: edit.zsh
         name: vim ~/.zshrc
@@ -205,32 +282,35 @@ commands:
         commands: {}
         subs: {}
         code:
-          language: ''
-          snippet: ''
+          language: ""
+          snippet: ""
         mode: 0
+        disabled: false
     subs: {}
     code:
-      language: ''
-      snippet: ''
+      language: ""
+      snippet: ""
     mode: 0
+    disabled: false
   gcdf:
     keypath: gcdf
     name: git clean -df
     alias: gcdf
     aliasonly: true
-    description: ''
+    description: Clean untracked directories and files in Git
     commands: {}
     subs: {}
     code:
-      language: ''
-      snippet: ''
+      language: ""
+      snippet: ""
     mode: 0
+    disabled: false
   ios:
     keypath: ios
-    name: ''
+    name: ""
     alias: ios
     aliasonly: false
-    description: ''
+    description: ""
     commands:
       record:
         keypath: ios.record
@@ -241,9 +321,10 @@ commands:
         commands: {}
         subs: {}
         code:
-          language: ''
-          snippet: ''
+          language: ""
+          snippet: ""
         mode: 0
+        disabled: false
       snap:
         keypath: ios.snap
         name: xcrun simctl io booted screenshot $1
@@ -253,20 +334,22 @@ commands:
         commands: {}
         subs: {}
         code:
-          language: ''
-          snippet: ''
+          language: ""
+          snippet: ""
         mode: 0
+        disabled: false
     subs: {}
     code:
-      language: ''
-      snippet: ''
+      language: ""
+      snippet: ""
     mode: 0
+    disabled: false
   ip:
     keypath: ip
-    name: ''
+    name: ""
     alias: ip
     aliasonly: false
-    description: ''
+    description: ""
     commands:
       local:
         keypath: ip.local
@@ -277,9 +360,10 @@ commands:
         commands: {}
         subs: {}
         code:
-          language: ''
-          snippet: ''
+          language: ""
+          snippet: ""
         mode: 0
+        disabled: false
       public:
         keypath: ip.public
         name: curl ifconfig.me
@@ -289,20 +373,22 @@ commands:
         commands: {}
         subs: {}
         code:
-          language: ''
-          snippet: ''
+          language: ""
+          snippet: ""
         mode: 0
+        disabled: false
     subs: {}
     code:
-      language: ''
-      snippet: ''
+      language: ""
+      snippet: ""
     mode: 0
+    disabled: false
   nuke:
     keypath: nuke
-    name: ''
+    name: ""
     alias: nuke
     aliasonly: false
-    description: ''
+    description: ""
     commands:
       docker:
         keypath: nuke.docker
@@ -313,9 +399,10 @@ commands:
         commands: {}
         subs: {}
         code:
-          language: ''
-          snippet: ''
+          language: ""
+          snippet: ""
         mode: 0
+        disabled: false
       ds:
         keypath: nuke.ds
         name: find . -type f -name '*.DS_Store' -ls -delete
@@ -325,14 +412,16 @@ commands:
         commands: {}
         subs: {}
         code:
-          language: ''
-          snippet: ''
+          language: ""
+          snippet: ""
         mode: 0
+        disabled: false
     subs: {}
     code:
-      language: ''
-      snippet: ''
+      language: ""
+      snippet: ""
     mode: 0
+    disabled: false
   reload:
     keypath: reload
     name: . ~/.zshrc
@@ -342,30 +431,7 @@ commands:
     commands: {}
     subs: {}
     code:
-      language: ''
-      snippet: ''
+      language: ""
+      snippet: ""
     mode: 0
-  update:
-    keypath: update
-    name: ''
-    alias: update
-    aliasonly: false
-    description: ''
-    commands:
-      brew:
-        keypath: update.brew
-        name: brew update && brew upgrade --all && brew cask update && brew cleanup && brew cask cleanup
-        alias: brew
-        aliasonly: false
-        description: Update everything related to brew and clean up
-        commands: {}
-        subs: {}
-        code:
-          language: ''
-          snippet: ''
-        mode: 0
-    subs: {}
-    code:
-      language: ''
-      snippet: ''
-    mode: 0
+    disabled: false

--- a/model/command.go
+++ b/model/command.go
@@ -27,6 +27,31 @@ type Command struct {
 	Disabled    bool                     `json:"disabled"`
 }
 
+// newCommand returns a newly initialized command
+func newCommand(name, alias, description string, code *Code, aliasOnly bool, mode string) *Command {
+	// Default alias to same as command name
+	if len(alias) == 0 {
+		alias = name
+	}
+
+	if code == nil {
+		code = &Code{}
+	}
+
+	return &Command{
+		KeyPath:     alias,
+		Name:        name,
+		Alias:       alias,
+		AliasOnly:   aliasOnly,
+		Description: description,
+		Commands:    map[string]*Command{},
+		Subs:        map[string]*Substitution{},
+		Code:        code,
+		Mode:        ModeFromString(mode),
+		Disabled:    false,
+	}
+}
+
 func (c *Command) String() string {
 	return fmt.Sprintf("[%s] %s -> %s", c.KeyPath, c.Name, c.Alias)
 }
@@ -87,31 +112,6 @@ func (c *Command) CobraCommand() *cobra.Command {
 	return cmd
 }
 
-// newCommand returns a newly initialized command
-func newCommand(name, alias, description string, code *Code, aliasOnly bool, mode string) *Command {
-	// Default alias to same as command name
-	if len(alias) == 0 {
-		alias = name
-	}
-
-	if code == nil {
-		code = &Code{}
-	}
-
-	return &Command{
-		KeyPath:     alias,
-		Name:        name,
-		Alias:       alias,
-		AliasOnly:   aliasOnly,
-		Description: description,
-		Commands:    map[string]*Command{},
-		Subs:        map[string]*Substitution{},
-		Code:        code,
-		Mode:        ModeFromString(mode),
-		Disabled:    false,
-	}
-}
-
 func (c *Command) effectiveCommand() string {
 	if c.Code.valid() {
 		return c.Code.Snippet
@@ -134,7 +134,7 @@ func (c *Command) addCommand(cmd *Command) {
 
 	c.Commands[cmd.Alias] = cmd
 	cmd.parent = c
-	cmd.KeyPath = keypath.KeyPath([]string{c.KeyPath, cmd.Alias})
+	cmd.updateRootKeyPath(c.KeyPath)
 }
 
 // removeCommand at this scope

--- a/model/manifest.go
+++ b/model/manifest.go
@@ -117,6 +117,27 @@ func (m *Manifest) RemoveCommand(keyPath string) (bool, error) {
 	return isRoot, nil
 }
 
+// RenameCommand and update subtree
+func (m *Manifest) RenameCommand(keyPath, name, description string) error {
+	cmd := m.Find(keyPath)
+	if cmd == nil {
+		return fmt.Errorf("command not found")
+	}
+
+	cmd.Alias = name
+	if len(description) > 0 {
+		cmd.Description = description
+	}
+
+	var root string
+	if p := cmd.parent; p != nil {
+		root = p.KeyPath
+	}
+	cmd.updateRootKeyPath(root)
+
+	return nil
+}
+
 // AddSubstitution with name and alias at key path
 func (m *Manifest) AddSubstitution(keyPath, name, alias string) error {
 	cmd := m.Find(keyPath)
@@ -225,9 +246,22 @@ func (m *Manifest) Children() []tree.Node {
 	return nodes
 }
 
-func (m *Manifest) ImportCommands(cmds []*Command, kp, description string) {
+func (m *Manifest) ImportCommands(cmds []*Command, kp, description string, create bool) error {
 	// Check if keypath exists
 	root := m.Find(kp)
+	if root == nil && create && len(kp) > 0 {
+		// Create destination key path
+		_, err := m.AddCommand(kp, "", description, nil, false, "")
+		if err != nil {
+			return err
+		}
+
+		root = m.Find(kp)
+		if root == nil {
+			return fmt.Errorf("root command should exist")
+		}
+	}
+
 	if root != nil {
 		// Add individual commands
 		for _, c := range cmds {
@@ -238,7 +272,7 @@ func (m *Manifest) ImportCommands(cmds []*Command, kp, description string) {
 			root.Description = description
 		}
 
-		return
+		return nil
 	}
 
 	// Keypath not found, add commands to root
@@ -247,7 +281,7 @@ func (m *Manifest) ImportCommands(cmds []*Command, kp, description string) {
 		m.Commands[c.Name] = c
 	}
 
-	return
+	return nil
 }
 
 // count of the total number of commands in this manifest

--- a/model/manifest.go
+++ b/model/manifest.go
@@ -233,10 +233,15 @@ func (m *Manifest) ImportCommands(cmds []*Command, kp, description string) {
 		for _, c := range cmds {
 			root.addCommand(c)
 		}
+
+		if len(description) > 0 {
+			root.Description = description
+		}
+
 		return
 	}
 
-	// Keypath found, add commands to root
+	// Keypath not found, add commands to root
 	for _, c := range cmds {
 		c.updateRootKeyPath("")
 		m.Commands[c.Name] = c

--- a/task/task.go
+++ b/task/task.go
@@ -660,6 +660,8 @@ func Detach(name string, keyPaths []string, targetKeyPath, description string, k
 		return -1
 	}
 
+	log.Highlightf("detached %s into %s manifest\n", strings.Join(keyPaths, ", "), name)
+
 	return 0
 }
 

--- a/task/task.go
+++ b/task/task.go
@@ -377,6 +377,8 @@ func RemoveCommand(keyPath string) int {
 		return -1
 	}
 
+	log.Highlightf("removed command %s\n", keyPath)
+
 	return 0
 }
 
@@ -399,12 +401,43 @@ func MoveCommand(source, dest, description string) int {
 		return -1
 	}
 
-	m.ImportCommands([]*model.Command{cmd}, dest, description)
+	if err := m.ImportCommands([]*model.Command{cmd}, dest, description, true); err != nil {
+		log.Error(err)
+		return -1
+	}
 
 	if err := saveConfig(cfg, false); err != nil {
 		log.Error(err)
 		return -1
 	}
+
+	if len(dest) == 0 {
+		dest = "root"
+	}
+	log.Highlightf("moved %s command to %s\n", source, dest)
+
+	return 0
+}
+
+// RenameCommand to a different name
+func RenameCommand(source, dest, description string) int {
+	cfg := checkConfig()
+	if cfg == nil {
+		return -1
+	}
+
+	m := cfg.Spaceport().CoreManifest()
+	if err := m.RenameCommand(source, dest, description); err != nil {
+		log.Error(err)
+		return -1
+	}
+
+	if err := saveConfig(cfg, false); err != nil {
+		log.Error(err)
+		return -1
+	}
+
+	log.Highlightf("renamed %s command to %s\n", source, dest)
 
 	return 0
 }
@@ -452,6 +485,8 @@ func RemoveSubstitution(keyPath, alias string) int {
 		log.Error(err)
 		return -1
 	}
+
+	log.Highlightf("removed substitution %s for command %s\n", alias, keyPath)
 
 	return 0
 }
@@ -592,7 +627,7 @@ func Detach(name string, keyPaths []string, targetKeyPath, description string, k
 	}
 
 	// Merge or add commands to manifest
-	m.ImportCommands(cmds, targetKeyPath, description)
+	m.ImportCommands(cmds, targetKeyPath, description, false)
 
 	// Remove original node if needed, only applies to core manifest
 	if !keepOriginal {

--- a/task/task.go
+++ b/task/task.go
@@ -380,6 +380,35 @@ func RemoveCommand(keyPath string) int {
 	return 0
 }
 
+// MoveCommand from one node to another
+func MoveCommand(source, dest, description string) int {
+	cfg := checkConfig()
+	if cfg == nil {
+		return -1
+	}
+
+	m := cfg.Spaceport().CoreManifest()
+	cmd := m.Find(source)
+	if cmd == nil {
+		log.Errorf("%s command not found", source)
+		return -1
+	}
+
+	if _, err := m.RemoveCommand(source); err != nil {
+		log.Error(err)
+		return -1
+	}
+
+	m.ImportCommands([]*model.Command{cmd}, dest, description)
+
+	if err := saveConfig(cfg, false); err != nil {
+		log.Error(err)
+		return -1
+	}
+
+	return 0
+}
+
 // AddSubstitution to the manifest
 func AddSubstitution(keyPath, name, alias string) int {
 	cfg := checkConfig()


### PR DESCRIPTION
Resolves #50 

Add a new move command that handles both moving command nodes as well as renaming them.
```sh
nostromo move [source] [dest] [options]
```
where options include:
- `-d` for adding a destination description
- `-r` for renaming the source key path only

Update examples for dock/sync.