### PR TITLE
Fix odd reversed strings in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ foo bar baz sls
 would finally result in the following since the substitution is in scope:
 
 ```sh
-oof rab zab //some/long/string
+foo bar baz //some/long/string
 ```
 
 ### Complex Command Tree


### PR DESCRIPTION
For some reason this commands's key paths were reversed.

Thanks for the awesome tool. I can't imagine going back to vanilla aliases again. <3